### PR TITLE
Add build and settings views and navigation

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -16,6 +16,12 @@
         <DataTemplate DataType="{x:Type vm:DecompileViewModel}">
             <views:DecompileView/>
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:BuildViewModel}">
+            <views:BuildView/>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
+            <views:SettingsView/>
+        </DataTemplate>
     </Window.Resources>
 
     <Border Background="{StaticResource Brush.Background}" CornerRadius="15" BorderBrush="{StaticResource Brush.BorderGlow}" BorderThickness="1">

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -1,0 +1,8 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace APKToolUI.ViewModels
+{
+    public partial class BuildViewModel : ObservableObject
+    {
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -27,13 +27,13 @@ namespace APKToolUI.ViewModels
         [RelayCommand]
         private void NavigateToBuild()
         {
-            // CurrentView = new BuildViewModel();
+            CurrentView = new BuildViewModel();
         }
 
         [RelayCommand]
         private void NavigateToSettings()
         {
-            // CurrentView = new SettingsViewModel();
+            CurrentView = new SettingsViewModel();
         }
     }
 }

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,8 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace APKToolUI.ViewModels
+{
+    public partial class SettingsViewModel : ObservableObject
+    {
+    }
+}

--- a/Views/BuildView.xaml
+++ b/Views/BuildView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="APKToolUI.Views.BuildView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <Grid Margin="20">
+        <TextBlock Text="Build" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold"/>
+    </Grid>
+</UserControl>

--- a/Views/BuildView.xaml.cs
+++ b/Views/BuildView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace APKToolUI.Views
+{
+    public partial class BuildView : UserControl
+    {
+        public BuildView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="APKToolUI.Views.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <Grid Margin="20">
+        <TextBlock Text="Settings" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold"/>
+    </Grid>
+</UserControl>

--- a/Views/SettingsView.xaml.cs
+++ b/Views/SettingsView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace APKToolUI.Views
+{
+    public partial class SettingsView : UserControl
+    {
+        public SettingsView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Build and Settings view models and views and template them in the main window
- update navigation commands to switch the current view to build or settings
- wire sidebar buttons through data templates so the UI swaps between views

## Testing
- ⚠️ `dotnet build` *(command unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b98d6d248322bd67c5fed5218c6e)