### PR TITLE
Fix settings view text box style reference

### DIFF
--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -11,7 +11,7 @@
 
             <TextBlock Text="Apktool Path" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,0,0,5"/>
             <DockPanel>
-                <TextBox Text="{Binding ApktoolPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CyberTextBoxStyle}" Width="400"/>
+                <TextBox Text="{Binding ApktoolPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CyberTextBox}" Width="400"/>
                 <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0"/>
                 <Button Content="Save" Command="{Binding SaveSettingsCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0"/>
             </DockPanel>


### PR DESCRIPTION
## Summary
- correct Settings view text box style key to match defined resources

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931bc0e61648322992ee8e1b2bdd50b)