### PR TITLE
Fix dashboard browse button functionality

### DIFF
--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -15,6 +15,9 @@ namespace APKToolUI.ViewModels
         [ObservableProperty]
         private bool _decodeSources = true;
 
+        [ObservableProperty]
+        private string? _outputFolder;
+
         private readonly Services.IFilePickerService _filePickerService;
         private readonly Services.ISettingsService _settingsService;
         private readonly Services.ApktoolRunner _apktoolRunner;
@@ -37,12 +40,23 @@ namespace APKToolUI.ViewModels
         }
 
         [RelayCommand]
+        private void BrowseOutputFolder()
+        {
+            var folder = _filePickerService.OpenFolder();
+            if (folder != null)
+            {
+                OutputFolder = folder;
+            }
+        }
+
+        [RelayCommand]
         private async Task RunDecompile()
         {
             if (string.IsNullOrEmpty(ApkPath)) return;
 
-            // TODO: Get output folder from UI or default to APK folder
-            var outputDir = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(ApkPath)!, System.IO.Path.GetFileNameWithoutExtension(ApkPath));
+            var outputDir = !string.IsNullOrWhiteSpace(OutputFolder)
+                ? OutputFolder
+                : System.IO.Path.Combine(System.IO.Path.GetDirectoryName(ApkPath)!, System.IO.Path.GetFileNameWithoutExtension(ApkPath));
 
             await _apktoolRunner.RunDecompileAsync(ApkPath, outputDir, DecodeResources, DecodeSources);
         }

--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -60,8 +60,8 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox Text="Output folder" Style="{StaticResource CyberTextBox}" Height="30" VerticalContentAlignment="Center" Background="{StaticResource Brush.Panel}" Foreground="{StaticResource Brush.TextPrimary}" BorderBrush="{StaticResource Brush.BorderGlow}"/>
-                    <Button Grid.Column="1" Content="Browse >" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Height="30" Padding="10,0"/>
+                    <TextBox Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue='Output folder'}" Style="{StaticResource CyberTextBox}" Height="30" VerticalContentAlignment="Center" Background="{StaticResource Brush.Panel}" Foreground="{StaticResource Brush.TextPrimary}" BorderBrush="{StaticResource Brush.BorderGlow}"/>
+                    <Button Grid.Column="1" Content="Browse >" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Height="30" Padding="10,0" Command="{Binding BrowseOutputFolderCommand}"/>
                 </Grid>
             </StackPanel>
         </Grid>


### PR DESCRIPTION
## Summary
- bind the dashboard output folder browse button to a command
- add output folder selection handling and use it for decompile output

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931bccd367c832296cc0c68e1ac592b)