### PR TITLE
Fix minimize button on dashboard

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -53,7 +53,7 @@
 
                 <!-- Window Controls Placeholder (Close/Min/Max) -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,10,0">
-                    <Button Content="_" Width="30" Height="20" Style="{StaticResource CyberButtonStyle}" Padding="0"/>
+                    <Button Content="_" Width="30" Height="20" Style="{StaticResource CyberButtonStyle}" Padding="0" Click="MinimizeButton_Click"/>
                     <Button Content="X" Width="30" Height="20" Style="{StaticResource CyberButtonStyle}" Padding="0" Margin="5,0,0,0" Click="CloseButton_Click"/>
                 </StackPanel>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,5 +17,10 @@ namespace APKToolUI
         {
             Close();
         }
+
+        private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            WindowState = WindowState.Minimized;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add click handler to minimize button on dashboard title bar
- set window state to minimized when the button is clicked

## Testing
- Not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c06883c883228f45900907db4090)