### PR TITLE
Simplify navigation menu

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -36,11 +36,8 @@
                 <StackPanel Margin="20">
                     <TextBlock Text="APKTool UI" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" Margin="0,0,0,40"/>
 
-                    <Button Content="Dashboard" Command="{Binding NavigateToDecompileCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
                     <Button Content="Decompile" Command="{Binding NavigateToDecompileCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
-                    <Button Content="Build" Command="{Binding NavigateToBuildCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
                     <Button Content="Settings" Command="{Binding NavigateToSettingsCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
-                    <Button Content="Task History" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
## Summary
- rename the Dashboard navigation entry to Decompile
- remove unused Decompile, Build, and Task History sidebar buttons to simplify navigation

## Testing
- dotnet build (fails: command not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b32e19c48322a382f10ab858744b)