### PR TITLE
Relax unsafe output directory detection

### DIFF
--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -145,9 +145,7 @@ namespace APKToolUI.ViewModels
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
                 Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                outputRoot,
-                Path.GetFullPath(Path.GetTempPath())
+                outputRoot
             };
 
             if (!string.IsNullOrWhiteSpace(outputRoot) && string.Equals(normalizedOutput, NormalizePath(outputRoot), StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary
- limit unsafe output directory detection to system directories so normal user paths are allowed

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932bb0cad1c8322bdbae662a104100c)