### PR TITLE
Fix unsafe output folder detection

### DIFF
--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -144,8 +144,7 @@ namespace APKToolUI.ViewModels
                 Environment.GetFolderPath(Environment.SpecialFolder.System),
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
                 Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-                outputRoot
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
             };
 
             if (!string.IsNullOrWhiteSpace(outputRoot) && string.Equals(normalizedOutput, NormalizePath(outputRoot), StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary
- reintroduce output folder safety validation while avoiding false positives caused by treating the drive root as unsafe for all subfolders
- keep guard to warn only on system-critical directories or the root itself

## Testing
- not run (dotnet SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932bddd5aa0832294e791b946e08d0d)