### PR TITLE
Handle apktool failures during decompile

### DIFF
--- a/Services/ApktoolRunner.cs
+++ b/Services/ApktoolRunner.cs
@@ -23,7 +23,7 @@ namespace APKToolUI.Services
             _settingsService = settingsService;
         }
 
-        public async Task RunDecompileAsync(string apkPath, string outputDir, bool decodeResources, bool decodeSources, bool keepOriginalManifest, bool keepUnknownFiles, bool forceOverwrite = false, CancellationToken cancellationToken = default)
+        public async Task<int> RunDecompileAsync(string apkPath, string outputDir, bool decodeResources, bool decodeSources, bool keepOriginalManifest, bool keepUnknownFiles, bool forceOverwrite = false, CancellationToken cancellationToken = default)
         {
             var args = new StringBuilder("d");
             args.Append($" \"{apkPath}\"");
@@ -39,10 +39,10 @@ namespace APKToolUI.Services
                 args.Append(" -f"); // Force overwrite
             }
 
-            await RunProcessAsync(args.ToString(), cancellationToken);
+            return await RunProcessAsync(args.ToString(), cancellationToken);
         }
 
-        private async Task RunProcessAsync(string arguments, CancellationToken cancellationToken)
+        private async Task<int> RunProcessAsync(string arguments, CancellationToken cancellationToken)
         {
             var apktoolPath = _settingsService.Settings.ApktoolPath;
 
@@ -91,6 +91,8 @@ namespace APKToolUI.Services
             process.BeginErrorReadLine();
 
             await process.WaitForExitAsync(cancellationToken);
+
+            return process.ExitCode;
         }
     }
 }

--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -105,8 +105,25 @@ namespace APKToolUI.ViewModels
                 }
             }
 
-            await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, KeepUnknownFiles, forceOverwrite);
-            AppendLog("Decompile finished.");
+            try
+            {
+                var exitCode = await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, KeepUnknownFiles, forceOverwrite);
+
+                if (exitCode == 0)
+                {
+                    AppendLog("Decompile finished.");
+                }
+                else
+                {
+                    AppendLog($"Decompile failed with exit code {exitCode}. Check the log above for details.");
+                    MessageBox.Show("Apktool reported an error while decompiling. Please review the console log for details.", "Decompile failed", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"Decompile failed: {ex.Message}");
+                MessageBox.Show(ex.Message, "Decompile failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void OnOutputDataReceived(string message)


### PR DESCRIPTION
## Summary
- return apktool exit codes from the runner
- report decompile failures in the view model with user-facing error messages

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c049117c83229c39b87b3b512b0c)