### PR TITLE
Remove unsupported keep unknown files option

### DIFF
--- a/Services/ApktoolRunner.cs
+++ b/Services/ApktoolRunner.cs
@@ -23,7 +23,7 @@ namespace APKToolUI.Services
             _settingsService = settingsService;
         }
 
-        public async Task<int> RunDecompileAsync(string apkPath, string outputDir, bool decodeResources, bool decodeSources, bool keepOriginalManifest, bool keepUnknownFiles, bool forceOverwrite = false, CancellationToken cancellationToken = default)
+        public async Task<int> RunDecompileAsync(string apkPath, string outputDir, bool decodeResources, bool decodeSources, bool keepOriginalManifest, bool forceOverwrite = false, CancellationToken cancellationToken = default)
         {
             var args = new StringBuilder("d");
             args.Append($" \"{apkPath}\"");
@@ -32,7 +32,6 @@ namespace APKToolUI.Services
             if (!decodeResources) args.Append(" -r");
             if (!decodeSources) args.Append(" -s");
             if (keepOriginalManifest) args.Append(" -m");
-            if (keepUnknownFiles) args.Append(" -u");
 
             if (forceOverwrite)
             {

--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -23,9 +23,6 @@ namespace APKToolUI.ViewModels
         private bool _keepOriginalManifest;
 
         [ObservableProperty]
-        private bool _keepUnknownFiles;
-
-        [ObservableProperty]
         private string? _outputFolder;
 
         [ObservableProperty]
@@ -107,7 +104,7 @@ namespace APKToolUI.ViewModels
 
             try
             {
-                var exitCode = await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, KeepUnknownFiles, forceOverwrite);
+                var exitCode = await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, forceOverwrite);
 
                 if (exitCode == 0)
                 {

--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -47,7 +47,6 @@
                 <CheckBox Content="Decode resources" IsChecked="{Binding DecodeResources}" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,5" ToolTip="When unchecked, resources.arsc will be left intact (-r)."/>
                 <CheckBox Content="Decode sources" IsChecked="{Binding DecodeSources}" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,5" ToolTip="When unchecked, smali code will be skipped (-s)."/>
                 <CheckBox Content="Keep original manifest" IsChecked="{Binding KeepOriginalManifest}" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,5" ToolTip="Preserve the original AndroidManifest.xml when decoding (-m)."/>
-                <CheckBox Content="Keep unknown files" IsChecked="{Binding KeepUnknownFiles}" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,5" ToolTip="Retain unknown files and directories during decode (-u)."/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">


### PR DESCRIPTION
## Summary
- remove the keep unknown files option from the UI and runner since apktool does not support -u
- simplify decompile call signature to match supported flags

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c171e9c483228514f88265fc93c8)