### PR TITLE
Handle existing decompile output directories

### DIFF
--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -89,6 +89,7 @@ namespace APKToolUI.ViewModels
             if (Directory.Exists(normalizedOutputDir))
             {
                 var isEmpty = !Directory.EnumerateFileSystemEntries(normalizedOutputDir).Any();
+
                 if (!isEmpty)
                 {
                     var result = MessageBox.Show($"The output directory '{normalizedOutputDir}' already exists and is not empty. Overwrite its contents?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
@@ -97,9 +98,9 @@ namespace APKToolUI.ViewModels
                     {
                         return;
                     }
-
-                    forceOverwrite = true;
                 }
+
+                forceOverwrite = true;
             }
 
             try


### PR DESCRIPTION
## Summary
- ensure decompile operations force overwrite when the target directory already exists to avoid apktool destination errors
- keep the user confirmation prompt for non-empty output directories

## Testing
- dotnet build *(fails: .NET SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c28fefe883228c3754ec0a9902aa)