### PR TITLE
Auto-save apktool path on selection

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,7 @@ namespace APKToolUI.ViewModels
     {
         private readonly Services.ISettingsService _settingsService;
         private readonly Services.IFilePickerService _filePickerService;
+        private readonly bool _isInitialized;
 
         [ObservableProperty]
         private string _apktoolPath;
@@ -22,6 +23,8 @@ namespace APKToolUI.ViewModels
             _filePickerService = filePickerService;
 
             ApktoolPath = _settingsService.Settings.ApktoolPath;
+
+            _isInitialized = true;
         }
 
         [RelayCommand]
@@ -34,10 +37,14 @@ namespace APKToolUI.ViewModels
             }
         }
 
-        [RelayCommand]
-        private void SaveSettings()
+        partial void OnApktoolPathChanged(string value)
         {
-            _settingsService.Settings.ApktoolPath = ApktoolPath?.Trim() ?? string.Empty;
+            if (!_isInitialized)
+            {
+                return;
+            }
+
+            _settingsService.Settings.ApktoolPath = value?.Trim() ?? string.Empty;
             _settingsService.Save();
         }
     }

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -13,7 +13,6 @@
             <DockPanel>
                 <TextBox Text="{Binding ApktoolPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CyberTextBox}" Width="400"/>
                 <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0"/>
-                <Button Content="Save" Command="{Binding SaveSettingsCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0"/>
             </DockPanel>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
## Summary
- remove the manual Save button from the Settings screen
- automatically persist the Apktool path whenever it is changed via browsing or editing

## Testing
- dotnet build (not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c5441a808322867ddf769b4abb8d)