### PR TITLE
Remove unused Build menu option

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -16,9 +16,6 @@
         <DataTemplate DataType="{x:Type vm:DecompileViewModel}">
             <views:DecompileView/>
         </DataTemplate>
-        <DataTemplate DataType="{x:Type vm:BuildViewModel}">
-            <views:BuildView/>
-        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
             <views:SettingsView/>
         </DataTemplate>
@@ -36,8 +33,50 @@
                 <StackPanel Margin="20">
                     <TextBlock Text="APKTool UI" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" Margin="0,0,0,40"/>
 
-                    <Button Content="Decompile" Command="{Binding NavigateToDecompileCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
-                    <Button Content="Settings" Command="{Binding NavigateToSettingsCommand}" Style="{StaticResource CyberButtonStyle}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left" Margin="0,5"/>
+                    <Button Content="Decompile" Command="{Binding NavigateToDecompileCommand}">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                                <Setter Property="Margin" Value="0,5"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMenu}" Value="Decompile">
+                                        <Setter Property="Background" Value="#3300F0FF"/>
+                                        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+                                        <Setter Property="BorderBrush" Value="{StaticResource Brush.AccentCyan}"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                        <Setter Property="Effect">
+                                            <Setter.Value>
+                                                <DropShadowEffect Color="{StaticResource Color.NeonCyan}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
+                    <Button Content="Settings" Command="{Binding NavigateToSettingsCommand}">
+                        <Button.Style>
+                            <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
+                                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                                <Setter Property="Margin" Value="0,5"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMenu}" Value="Settings">
+                                        <Setter Property="Background" Value="#3300F0FF"/>
+                                        <Setter Property="Foreground" Value="{StaticResource Brush.TextPrimary}"/>
+                                        <Setter Property="BorderBrush" Value="{StaticResource Brush.AccentCyan}"/>
+                                        <Setter Property="FontWeight" Value="Bold"/>
+                                        <Setter Property="Effect">
+                                            <Setter.Value>
+                                                <DropShadowEffect Color="{StaticResource Color.NeonCyan}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
                 </StackPanel>
             </Border>
 

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -12,6 +12,9 @@ namespace APKToolUI.ViewModels
         [ObservableProperty]
         private string _windowTitle = "APKTool UI";
 
+        [ObservableProperty]
+        private string _selectedMenu = "Decompile";
+
         public MainViewModel()
         {
             // Default view
@@ -22,18 +25,14 @@ namespace APKToolUI.ViewModels
         private void NavigateToDecompile()
         {
             CurrentView = new DecompileViewModel();
-        }
-
-        [RelayCommand]
-        private void NavigateToBuild()
-        {
-            CurrentView = new BuildViewModel();
+            SelectedMenu = "Decompile";
         }
 
         [RelayCommand]
         private void NavigateToSettings()
         {
             CurrentView = new SettingsViewModel();
+            SelectedMenu = "Settings";
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the Build view template and navigation command since the menu item is no longer needed
- keep the sidebar limited to Decompile and Settings while preserving the selection highlighting

## Testing
- dotnet build *(fails: `dotnet` CLI is not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c62cb7848322b07557ec897aa0b0)