### PR TITLE
Improve title bar buttons

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -89,8 +89,10 @@
 
                 <!-- Window Controls Placeholder (Close/Min/Max) -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,5,10,0">
-                    <Button Content="_" Width="30" Height="20" Style="{StaticResource CyberButtonStyle}" Padding="0" Click="MinimizeButton_Click"/>
-                    <Button Content="X" Width="30" Height="20" Style="{StaticResource CyberButtonStyle}" Padding="0" Margin="5,0,0,0" Click="CloseButton_Click"/>
+                    <Button Style="{StaticResource TitleBarButtonStyle}" Click="MinimizeButton_Click">
+                        <Rectangle Width="12" Height="2" RadiusX="1" RadiusY="1" Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" VerticalAlignment="Center"/>
+                    </Button>
+                    <Button Content="X" Style="{StaticResource TitleBarButtonStyle}" Margin="5,0,0,0" Click="CloseButton_Click"/>
                 </StackPanel>
 
                 <ContentControl Grid.Row="1" Content="{Binding CurrentView}"/>

--- a/Resources/Theme.xaml
+++ b/Resources/Theme.xaml
@@ -57,6 +57,42 @@
         </Setter>
     </Style>
 
+    <!-- Window Title Bar Button Style -->
+    <Style x:Key="TitleBarButtonStyle" TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
+        <Setter Property="Width" Value="36"/>
+        <Setter Property="Height" Value="24"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="12">
+                        <Border.Effect>
+                            <DropShadowEffect Color="{StaticResource Color.NeonCyan}" BlurRadius="10" ShadowDepth="0" Opacity="0.3"/>
+                        </Border.Effect>
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="#1A00F0FF"/>
+                            <Setter Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Color="{StaticResource Color.NeonCyan}" BlurRadius="20" ShadowDepth="0" Opacity="0.6"/>
+                                </Setter.Value>
+                            </Setter>
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="#3300F0FF"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Panel Style -->
     <Style x:Key="CyberPanelStyle" TargetType="Border">
         <Setter Property="Background" Value="{StaticResource Brush.Panel}"/>


### PR DESCRIPTION
## Summary
- add a dedicated title bar button style for consistent window control sizing
- render the minimize glyph with a centered rectangle for clearer appearance
- apply the new style to both minimize and close controls

## Testing
- Not run (dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330934abf883229e06feaa7af1efcb)