### PR TITLE
Widen Browse buttons

### DIFF
--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -56,7 +56,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <TextBox Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue='Output folder'}" Style="{StaticResource CyberTextBox}" Height="30" VerticalContentAlignment="Center" Background="{StaticResource Brush.Panel}" Foreground="{StaticResource Brush.TextPrimary}" BorderBrush="{StaticResource Brush.BorderGlow}"/>
-                    <Button Grid.Column="1" Content="Browse" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Height="30" Padding="10,0" Command="{Binding BrowseOutputFolderCommand}"/>
+                    <Button Grid.Column="1" Content="Browse" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Height="30" Padding="16,0" MinWidth="90" Command="{Binding BrowseOutputFolderCommand}"/>
                 </Grid>
             </StackPanel>
         </Grid>

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -12,7 +12,7 @@
             <TextBlock Text="Apktool Path" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,0,0,5"/>
             <DockPanel>
                 <TextBox Text="{Binding ApktoolPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CyberTextBox}" Width="400"/>
-                <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0"/>
+                <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Padding="16,0" MinWidth="90"/>
             </DockPanel>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
## Summary
- widen Browse buttons to provide more comfortable padding and minimum width
- keep styling consistent across decompile and settings views

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69330cd6954c83228a2a31b930ad9cc9)