### PR TITLE
Fix duplicate Background assignment

### DIFF
--- a/Resources/Theme.xaml
+++ b/Resources/Theme.xaml
@@ -77,8 +77,7 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <Border x:Name="OuterShell"
-                                CornerRadius="16"
-                                Background="#081018">
+                                CornerRadius="16">
                             <Border.Background>
                                 <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
                                     <GradientStop Color="#0E2430" Offset="0"/>


### PR DESCRIPTION
## Summary
- remove redundant Background attribute from the RunButtonStyle outer shell border to avoid duplicate property errors

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693311e4df5883228b45704565c1becf)