### PR TITLE
Rename UI branding to PulseAPK

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -31,7 +31,7 @@
             <!-- Sidebar -->
             <Border Grid.Column="0" BorderBrush="{StaticResource Brush.BorderGlow}" BorderThickness="0,0,1,0">
                 <StackPanel Margin="20">
-                    <TextBlock Text="APKTool UI" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" Margin="0,0,0,40"/>
+                    <TextBlock Text="PulseAPK" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" Margin="0,0,0,40"/>
 
                     <Button Content="Decompile" Command="{Binding NavigateToDecompileCommand}">
                         <Button.Style>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -10,7 +10,7 @@ namespace APKToolUI.ViewModels
         private object _currentView;
 
         [ObservableProperty]
-        private string _windowTitle = "APKTool UI";
+        private string _windowTitle = "PulseAPK";
 
         [ObservableProperty]
         private string _selectedMenu = "Decompile";


### PR DESCRIPTION
## Summary
- update the window title text to use the PulseAPK name
- update the sidebar header to display PulseAPK branding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693313c0d9b88322aa941abedf8b8ab8)