### PR TITLE
Store settings in application directory

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@ PulseAPK is a Windows Presentation Foundation (WPF) desktop client that wraps th
 - **Guided decompilation:** Choose the APK, toggle resource/source decoding, and preserve the original manifest when needed.
 - **Safe output handling:** Warns about risky output folders and prompts before overwriting existing directories.
 - **Live console log:** Streams apktool output and errors directly into the UI.
-- **Configurable settings:** Persist the apktool JAR path in a user-level settings file under the application data folder.
+- **Configurable settings:** Persist the apktool JAR path in a settings file stored alongside the application.
 
 ## Requirements
 - Windows with .NET 8.0 SDK (for building and running the project).
@@ -26,7 +26,7 @@ PulseAPK is a Windows Presentation Foundation (WPF) desktop client that wraps th
    dotnet run
    ```
 4. **Set the apktool path**
-   - Open the **Settings** view and browse to the `apktool.jar` location. The path is persisted to `%AppData%/APKToolUI/settings.json`.
+   - Open the **Settings** view and browse to the `apktool.jar` location. The path is persisted to `settings.json` within the application folder.
 
 ## How it works
 - The UI is defined in `MainWindow.xaml` with views for **Decompile** and **Settings** hosted via view models.

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -24,11 +24,7 @@ namespace APKToolUI.Services
 
         public SettingsService()
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            // Stores settings under %AppData%/APKToolUI (Windows) or ~/.config/APKToolUI (Linux/macOS)
-            var settingsFolder = Path.Combine(appData, "APKToolUI");
-            Directory.CreateDirectory(settingsFolder);
-
+            var settingsFolder = AppContext.BaseDirectory;
             _settingsFilePath = Path.Combine(settingsFolder, SettingsFileName);
             Settings = LoadSettings();
         }


### PR DESCRIPTION
## Summary
- save the settings file next to the application instead of under AppData
- update the README to describe the new settings location

## Testing
- dotnet build *(fails: command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693397fed3188322b577d77e794ff095)