### PR TITLE
Show Java path in settings

### DIFF
--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace APKToolUI.ViewModels
 {
@@ -14,6 +15,9 @@ namespace APKToolUI.ViewModels
         [ObservableProperty]
         private string _apktoolPath;
 
+        [ObservableProperty]
+        private string _javaPathDisplay;
+
         public SettingsViewModel()
             : this(new Services.SettingsService(), new Services.FilePickerService())
         {
@@ -25,6 +29,7 @@ namespace APKToolUI.ViewModels
             _filePickerService = filePickerService;
 
             ApktoolPath = _settingsService.Settings.ApktoolPath;
+            JavaPathDisplay = GetJavaPathDisplay();
 
             _isInitialized = true;
         }
@@ -66,6 +71,48 @@ namespace APKToolUI.ViewModels
 
             _settingsService.Settings.ApktoolPath = value?.Trim() ?? string.Empty;
             _settingsService.Save();
+        }
+
+        private static string GetJavaPathDisplay()
+        {
+            var javaPath = FindJavaExecutable();
+            if (string.IsNullOrWhiteSpace(javaPath))
+            {
+                return "JAVA Path: Not Found";
+            }
+
+            return $"JAVA Path: {javaPath}";
+        }
+
+        private static string FindJavaExecutable()
+        {
+            var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
+            if (!string.IsNullOrWhiteSpace(javaHome))
+            {
+                var javaHomePath = Path.Combine(javaHome, "bin", "java.exe");
+                if (File.Exists(javaHomePath))
+                {
+                    return javaHomePath;
+                }
+            }
+
+            var paths = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();
+            foreach (var path in paths)
+            {
+                var trimmedPath = path.Trim();
+                if (string.IsNullOrWhiteSpace(trimmedPath))
+                {
+                    continue;
+                }
+
+                var javaPath = Path.Combine(trimmedPath, "java.exe");
+                if (File.Exists(javaPath))
+                {
+                    return javaPath;
+                }
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -14,6 +14,7 @@
                 <TextBox Text="{Binding ApktoolPath, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource CyberTextBox}" Width="400"/>
                 <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Padding="16,0" MinWidth="90"/>
             </DockPanel>
+            <TextBlock Text="{Binding JavaPathDisplay}" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,5,0,0" TextWrapping="Wrap"/>
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- display the resolved Java executable path in the Settings screen
- detect Java from JAVA_HOME or PATH and show a not-found message when missing

## Testing
- dotnet build *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339c5f22dc83229bcf127e0812f38c)