### PR TITLE
Add download links for apktool and Java

### DIFF
--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -15,6 +15,16 @@
                 <Button Content="Browse" Command="{Binding BrowseApktoolCommand}" Style="{StaticResource CyberButtonStyle}" Margin="10,0,0,0" Padding="16,0" MinWidth="90"/>
             </DockPanel>
             <TextBlock Text="{Binding JavaPathDisplay}" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,5,0,0" TextWrapping="Wrap"/>
+            <StackPanel Margin="0,5,0,0">
+                <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap">
+                    <Run Text="Download Apktool: "/>
+                    <Hyperlink NavigateUri="https://bitbucket.org/iBotPeaches/apktool/downloads/" RequestNavigate="Hyperlink_RequestNavigate">https://bitbucket.org/iBotPeaches/apktool/downloads/</Hyperlink>
+                </TextBlock>
+                <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap" Margin="0,3,0,0">
+                    <Run Text="Download JAVA: "/>
+                    <Hyperlink NavigateUri="https://www.azul.com/downloads/?package=jdk#zulu" RequestNavigate="Hyperlink_RequestNavigate">https://www.azul.com/downloads/?package=jdk#zulu</Hyperlink>
+                </TextBlock>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Views/SettingsView.xaml.cs
+++ b/Views/SettingsView.xaml.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Windows.Controls;
+using System.Windows.Navigation;
 
 namespace APKToolUI.Views
 {
@@ -7,6 +9,16 @@ namespace APKToolUI.Views
         public SettingsView()
         {
             InitializeComponent();
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri)
+            {
+                UseShellExecute = true
+            });
+
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add download links for Apktool and Java in the settings view
- enable hyperlinks to open via the default browser

## Testing
- dotnet build (fails: command not found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933a320bc448322a915db465c0f3942)