### PR TITLE
Remove unused force rebuild option

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -322,15 +322,6 @@ namespace PulseAPK.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force Rebuild All.
-        /// </summary>
-        public static string ForceAll {
-            get {
-                return ResourceManager.GetString("ForceAll", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to JAVA Path: Not Found.
         /// </summary>
         public static string JavaPathNotFound {

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -181,15 +181,12 @@
   <data name="SelectProjectFolder" xml:space="preserve">
     <value>Select Project Folder</value>
   </data>
-  <data name="UseAapt2" xml:space="preserve">
-    <value>Use AAPT2</value>
-  </data>
-  <data name="ForceAll" xml:space="preserve">
-    <value>Force Rebuild All</value>
-  </data>
-  <data name="RunBuild" xml:space="preserve">
-    <value>Run Build</value>
-  </data>
+    <data name="UseAapt2" xml:space="preserve">
+      <value>Use AAPT2</value>
+    </data>
+    <data name="RunBuild" xml:space="preserve">
+      <value>Run Build</value>
+    </data>
   <data name="BuildSuccessful" xml:space="preserve">
     <value>APK file successfully created.</value>
   </data>

--- a/Services/ApktoolRunner.cs
+++ b/Services/ApktoolRunner.cs
@@ -41,15 +41,14 @@ namespace PulseAPK.Services
             return await RunProcessAsync(args.ToString(), cancellationToken);
         }
 
-        public async Task<int> RunBuildAsync(string projectPath, string outputApk, bool useAapt2, bool forceAll, CancellationToken cancellationToken = default)
+        public async Task<int> RunBuildAsync(string projectPath, string outputApk, bool useAapt2, CancellationToken cancellationToken = default)
         {
             var args = new StringBuilder("b");
             args.Append($" \"{projectPath}\"");
             args.Append($" -o \"{outputApk}\"");
 
             if (useAapt2) args.Append(" --use-aapt2");
-            if (forceAll) args.Append(" -f");
-            
+
             return await RunProcessAsync(args.ToString(), cancellationToken);
         }
 

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -23,9 +23,6 @@ namespace PulseAPK.ViewModels
         private bool _useAapt2;
 
         [ObservableProperty]
-        private bool _forceAll;
-
-        [ObservableProperty]
         private string _consoleLog = Properties.Resources.WaitingForCommand;
 
         [ObservableProperty]
@@ -74,7 +71,6 @@ namespace PulseAPK.ViewModels
 
         partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
         partial void OnUseAapt2Changed(bool value) => UpdateCommandPreview();
-        partial void OnForceAllChanged(bool value) => UpdateCommandPreview();
 
         [RelayCommand]
         private void BrowseProject()
@@ -140,7 +136,7 @@ namespace PulseAPK.ViewModels
 
             try
             {
-                var exitCode = await _apktoolRunner.RunBuildAsync(ProjectPath, OutputApkPath, UseAapt2, ForceAll);
+                var exitCode = await _apktoolRunner.RunBuildAsync(ProjectPath, OutputApkPath, UseAapt2);
 
                 if (exitCode == 0)
                 {

--- a/Views/BuildView.xaml
+++ b/Views/BuildView.xaml
@@ -57,7 +57,6 @@
 
             <StackPanel Grid.Column="0" Margin="0,0,40,0">
                 <CheckBox Content="{x:Static properties:Resources.UseAapt2}" IsChecked="{Binding UseAapt2}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
-                <CheckBox Content="{x:Static properties:Resources.ForceAll}" IsChecked="{Binding ForceAll}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">


### PR DESCRIPTION
## Summary
- remove the Force Rebuild All checkbox and its resource entry from the build view
- simplify the build command to omit the unused force rebuild flag
- update generated resources to reflect the removed option

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693668797e108322b30c03badb327bb9)