### PR TITLE
Style settings download links as buttons

### DIFF
--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -17,14 +17,28 @@
             </DockPanel>
             <TextBlock Text="{Binding JavaPathDisplay}" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,5,0,0" TextWrapping="Wrap"/>
             <StackPanel Margin="0,5,0,0">
-                <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap">
-                    <Run Text="{x:Static properties:Resources.DownloadApktool}"/>
-                    <Hyperlink NavigateUri="https://bitbucket.org/iBotPeaches/apktool/downloads/" RequestNavigate="Hyperlink_RequestNavigate">https://bitbucket.org/iBotPeaches/apktool/downloads/</Hyperlink>
-                </TextBlock>
-                <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap" Margin="0,3,0,0">
-                    <Run Text="{x:Static properties:Resources.DownloadJava}"/>
-                    <Hyperlink NavigateUri="https://www.azul.com/downloads/?package=jdk#zulu" RequestNavigate="Hyperlink_RequestNavigate">https://www.azul.com/downloads/?package=jdk#zulu</Hyperlink>
-                </TextBlock>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,3">
+                    <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap" VerticalAlignment="Center">
+                        <Run Text="{x:Static properties:Resources.DownloadApktool}"/>
+                    </TextBlock>
+                    <Button Content="https://bitbucket.org/iBotPeaches/apktool/downloads/"
+                            Style="{StaticResource CyberButtonStyle}"
+                            CommandParameter="https://bitbucket.org/iBotPeaches/apktool/downloads/"
+                            Click="LinkButton_Click"
+                            Margin="8,0,0,0"
+                            Padding="12,4"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Foreground="{StaticResource Brush.TextSecondary}" TextWrapping="Wrap" VerticalAlignment="Center">
+                        <Run Text="{x:Static properties:Resources.DownloadJava}"/>
+                    </TextBlock>
+                    <Button Content="https://www.azul.com/downloads/?package=jdk#zulu"
+                            Style="{StaticResource CyberButtonStyle}"
+                            CommandParameter="https://www.azul.com/downloads/?package=jdk#zulu"
+                            Click="LinkButton_Click"
+                            Margin="8,0,0,0"
+                            Padding="12,4"/>
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/Views/SettingsView.xaml.cs
+++ b/Views/SettingsView.xaml.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
+using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Navigation;
 
 namespace PulseAPK.Views
 {
@@ -11,14 +11,15 @@ namespace PulseAPK.Views
             InitializeComponent();
         }
 
-        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        private void LinkButton_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri)
+            if (sender is Button button && button.CommandParameter is string uri)
             {
-                UseShellExecute = true
-            });
-
-            e.Handled = true;
+                Process.Start(new ProcessStartInfo(uri)
+                {
+                    UseShellExecute = true
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- restyle download links in the settings view as buttons using the existing app button style
- add a shared button click handler to open the download URLs

## Testing
- Not run (dotnet command unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366aa0f4008322a3723f81c8f7ae99)