### PR TITLE
Ensure Build APK browse opens displayed folder

### DIFF
--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -107,21 +107,30 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void BrowseOutputApk()
         {
-            // User requested automatic path. 
-            // "Have a field to select the output directory" -> "Itstead of 'Output Folder' it should just be the current folder... + compiled"
-            // This implies the Browse button might be redundant or should potentially just show the folder?
-            // "The user requirement says 'Have a field to select the output directory', make sure it does NOT overwrite anything"
-            // Actually, in the latest prompt: "Itstead of 'Output Folder' it should just be the current folder... + compiled... It fill just create the file there"
-            // So we can keep the field read-only or just let them change the filename if they really want, but simpler to just auto-set it.
-            // I will keep the browse button but make it open the target folder location instead of picking a new one?
-            // Or just check if user wants to change it. 
-            // Let's assume standard browse behavior but defaulting to the 'compiled' logic.
-            
-            var folder = _filePickerService.OpenFolder();
-            if (folder != null)
+            var folder = string.IsNullOrWhiteSpace(OutputFolderPath)
+                ? EnsureCompiledDirectory()
+                : OutputFolderPath;
+
+            try
             {
-                OutputFolderPath = folder;
+                if (!Directory.Exists(folder))
+                {
+                    Directory.CreateDirectory(folder);
+                }
+
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = folder,
+                    UseShellExecute = true,
+                    Verb = "open"
+                });
             }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Unable to open folder: {ex.Message}", Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+            OutputFolderPath = folder;
         }
 
         [RelayCommand(CanExecute = nameof(CanRunBuild))]


### PR DESCRIPTION
## Summary
- update Build APK browse action to open the currently displayed output folder
- ensure the folder is created when needed so the path stays synchronized with the UI

## Testing
- not run (dotnet SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367dd00e388322ad0863992345e16f)