### PR TITLE
Default empty output folder to app root

### DIFF
--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -82,6 +82,16 @@ namespace PulseAPK.ViewModels
         partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
         partial void OnOutputFolderPathChanged(string value)
         {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                var defaultPath = GetApplicationRootPath();
+                if (!string.Equals(OutputFolderPath, defaultPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    OutputFolderPath = defaultPath;
+                    return;
+                }
+            }
+
             UpdateOutputApkPath();
             BrowseOutputApkCommand.NotifyCanExecuteChanged();
         }
@@ -268,6 +278,13 @@ namespace PulseAPK.ViewModels
             }
 
             return compiledDir;
+        }
+
+        private string GetApplicationRootPath()
+        {
+            return string.IsNullOrWhiteSpace(AppDomain.CurrentDomain.BaseDirectory)
+                ? Directory.GetCurrentDirectory()
+                : AppDomain.CurrentDomain.BaseDirectory;
         }
 
         private void UpdateOutputApkPath()


### PR DESCRIPTION
## Summary
- default the Build APK output folder to the application root when the field is left empty
- add helper to derive the application root path while preserving existing path updates

## Testing
- dotnet build *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368255fef48322a234b1800be98eac)