### PR TITLE
Fix build output browse to use folder picker

### DIFF
--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -112,28 +112,12 @@ namespace PulseAPK.ViewModels
         [RelayCommand(CanExecute = nameof(CanBrowseOutputApk))]
         private void BrowseOutputApk()
         {
-            var folder = EnsureOutputFolderPathInitialized();
+            var folder = _filePickerService.OpenFolder();
 
-            try
+            if (!string.IsNullOrWhiteSpace(folder))
             {
-                if (!Directory.Exists(folder))
-                {
-                    Directory.CreateDirectory(folder);
-                }
-
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = folder,
-                    UseShellExecute = true,
-                    Verb = "open"
-                });
+                OutputFolderPath = folder;
             }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Unable to open folder: {ex.Message}", Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-
-            OutputFolderPath = folder;
         }
 
         private bool CanBrowseOutputApk() => !string.IsNullOrWhiteSpace(OutputFolderPath);


### PR DESCRIPTION
## Summary
- change the Build APK browse action to open the folder picker instead of launching the directory
- keep output folder updates when a selection is made

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368bce7d848322a0fd8b4500fd80c9)