### PR TITLE
Align folder pickers with current paths

### DIFF
--- a/Services/FilePickerService.cs
+++ b/Services/FilePickerService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Win32;
+using System.IO;
 using System.Windows;
 
 namespace PulseAPK.Services
@@ -19,9 +20,15 @@ namespace PulseAPK.Services
             return null;
         }
 
-        public string? OpenFolder()
+        public string? OpenFolder(string? initialDirectory = null)
         {
             var dialog = new OpenFolderDialog();
+
+            if (!string.IsNullOrWhiteSpace(initialDirectory) && Directory.Exists(initialDirectory))
+            {
+                dialog.InitialDirectory = initialDirectory;
+            }
+
             if (dialog.ShowDialog() == true)
             {
                 return dialog.FolderName;

--- a/Services/IFilePickerService.cs
+++ b/Services/IFilePickerService.cs
@@ -3,6 +3,6 @@ namespace PulseAPK.Services
     public interface IFilePickerService
     {
         string? OpenFile(string filter);
-        string? OpenFolder();
+        string? OpenFolder(string? initialDirectory = null);
     }
 }

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -96,7 +96,7 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void BrowseProject()
         {
-            var folder = _filePickerService.OpenFolder();
+            var folder = _filePickerService.OpenFolder(ProjectPath);
             if (folder != null)
             {
                 var (isValid, message) = Utils.FileSanitizer.ValidateProjectFolder(folder);
@@ -112,7 +112,7 @@ namespace PulseAPK.ViewModels
         [RelayCommand(CanExecute = nameof(CanBrowseOutputApk))]
         private void BrowseOutputApk()
         {
-            var folder = _filePickerService.OpenFolder();
+            var folder = _filePickerService.OpenFolder(OutputFolderPath);
 
             if (!string.IsNullOrWhiteSpace(folder))
             {

--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -91,7 +91,7 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void BrowseOutputFolder()
         {
-            var folder = _filePickerService.OpenFolder();
+            var folder = _filePickerService.OpenFolder(OutputFolder);
             if (folder != null)
             {
                 OutputFolder = folder;


### PR DESCRIPTION
## Summary
- set folder picker dialogs to start in the currently selected path when available
- update browse actions to pass existing paths for build and decompile views
- allow folder picker service to accept an initial directory

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368dbe60f883229cba4205b7f33936)