### PR TITLE
Show compiled path in build command preview

### DIFF
--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -225,8 +225,8 @@ namespace PulseAPK.ViewModels
              var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
             var apktool = string.IsNullOrWhiteSpace(apktoolPath) ? "<set apktool path>" : $"\"{apktoolPath}\"";
             var project = string.IsNullOrWhiteSpace(ProjectPath) ? "<select project>" : $"\"{ProjectPath}\"";
-            var hasFileTarget = !string.IsNullOrWhiteSpace(OutputApkPath) && !Directory.Exists(OutputApkPath);
-            var output = hasFileTarget ? $"\"{OutputApkPath}\"" : "<output apk>";
+            var hasOutputPath = !string.IsNullOrWhiteSpace(OutputApkPath);
+            var output = hasOutputPath ? $"\"{OutputApkPath}\"" : "<output apk>";
 
             var builder = new StringBuilder();
             builder.Append($"java -jar {apktool} b {project} -o {output}");


### PR DESCRIPTION
## Summary
- always include the selected output path in the build command preview, even when it points to the default compiled directory

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368fbddcdc8322aa677b7bd42b78e4)