### PR TITLE
Handle invalid drag-and-drop in Build APK view

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -275,7 +275,16 @@ namespace PulseAPK.Properties {
                 return ResourceManager.GetString("Error_InvalidJarFile", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Drop a valid project folder that contains apktool.yml and AndroidManifest.xml..
+        /// </summary>
+        public static string Error_InvalidProjectSelection {
+            get {
+                return ResourceManager.GetString("Error_InvalidProjectSelection", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Please configure the apktool path in Settings before running a decompile..
         /// </summary>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -136,6 +136,9 @@
   <data name="Error_InvalidJarFile" xml:space="preserve">
     <value>Invalid Jar File</value>
   </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Drop a valid project folder that contains apktool.yml and AndroidManifest.xml.</value>
+  </data>
   <data name="FileFilter_Apk" xml:space="preserve">
     <value>APK Files (*.apk)|*.apk|All Files (*.*)|*.*</value>
   </data>

--- a/Views/BuildView.xaml.cs
+++ b/Views/BuildView.xaml.cs
@@ -45,6 +45,10 @@ namespace PulseAPK.Views
                              MessageBox.Show(message, Properties.Resources.Warning_InvalidProjectFolder, MessageBoxButton.OK, MessageBoxImage.Warning);
                         }
                     }
+                    else
+                    {
+                        MessageBox.Show(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.BuildHeader, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show a warning when a non-folder is dropped onto the Build APK area
- reuse project validation messaging for missing required files

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693691adf7588322bf505a5ebd9da95a)