### PR TITLE
Refactor browse handling into reusable utility

### DIFF
--- a/Utils/BrowseUtils.cs
+++ b/Utils/BrowseUtils.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+
+namespace PulseAPK.Utils
+{
+    public static class BrowseUtils
+    {
+        public static string? BrowseFolder(
+            Services.IFilePickerService filePickerService,
+            string? currentPath,
+            string? missingPathMessage,
+            string? folderNotFoundMessage,
+            bool requireExistingBasePath)
+        {
+            if (filePickerService == null)
+            {
+                throw new ArgumentNullException(nameof(filePickerService));
+            }
+
+            var hasBaseDirectory = TryNormalizeDirectory(currentPath, out var normalizedBaseDirectory);
+
+            if (requireExistingBasePath && !hasBaseDirectory)
+            {
+                ShowFolderError(currentPath, missingPathMessage, folderNotFoundMessage);
+                return null;
+            }
+
+            var selectedFolder = filePickerService.OpenFolder(hasBaseDirectory ? normalizedBaseDirectory : null);
+
+            if (!TryNormalizeDirectory(selectedFolder, out var normalizedSelection))
+            {
+                if (!string.IsNullOrWhiteSpace(selectedFolder))
+                {
+                    ShowFolderError(selectedFolder, missingPathMessage, folderNotFoundMessage);
+                }
+                return null;
+            }
+
+            return normalizedSelection;
+        }
+
+        public static bool TryOpenFolder(string? folderPath, string missingFolderMessage, string folderNotFoundMessage)
+        {
+            if (!TryNormalizeDirectory(folderPath, out var normalizedPath))
+            {
+                ShowFolderError(folderPath, missingFolderMessage, folderNotFoundMessage);
+                return false;
+            }
+
+            try
+            {
+                Process.Start("explorer.exe", normalizedPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(string.Format(Properties.Resources.Error_CouldNotOpenFolder, ex.Message), Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
+            }
+        }
+
+        private static bool TryNormalizeDirectory(string? path, out string normalizedPath)
+        {
+            normalizedPath = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                var fullPath = Path.GetFullPath(path.Trim());
+                if (!Directory.Exists(fullPath))
+                {
+                    return false;
+                }
+
+                normalizedPath = fullPath;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void ShowFolderError(string? path, string? missingPathMessage, string? folderNotFoundMessage)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                if (!string.IsNullOrWhiteSpace(missingPathMessage))
+                {
+                    MessageBox.Show(missingPathMessage, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(folderNotFoundMessage))
+            {
+                MessageBox.Show(string.Format(folderNotFoundMessage, path), Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+    }
+}

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -95,7 +95,13 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void BrowseProject()
         {
-            var folder = _filePickerService.OpenFolder(ProjectPath);
+            var folder = Utils.BrowseUtils.BrowseFolder(
+                _filePickerService,
+                ProjectPath,
+                missingPathMessage: null,
+                folderNotFoundMessage: Properties.Resources.Error_FolderNotFound,
+                requireExistingBasePath: false);
+
             if (folder != null)
             {
                 var (isValid, message) = Utils.FileSanitizer.ValidateProjectFolder(folder);
@@ -111,7 +117,12 @@ namespace PulseAPK.ViewModels
         [RelayCommand(CanExecute = nameof(CanBrowseOutputApk))]
         private void BrowseOutputApk()
         {
-            var folder = _filePickerService.OpenFolder(OutputFolderPath);
+            var folder = Utils.BrowseUtils.BrowseFolder(
+                _filePickerService,
+                OutputFolderPath,
+                Properties.Resources.Error_OutputFolderNotSet,
+                Properties.Resources.Error_FolderNotFound,
+                requireExistingBasePath: true);
 
             if (!string.IsNullOrWhiteSpace(folder))
             {

--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
 using System.Windows;
-using System.Diagnostics;
 
 namespace PulseAPK.ViewModels
 {
@@ -91,7 +90,13 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void BrowseOutputFolder()
         {
-            var folder = _filePickerService.OpenFolder(OutputFolder);
+            var folder = Utils.BrowseUtils.BrowseFolder(
+                _filePickerService,
+                OutputFolder,
+                Properties.Resources.Error_OutputFolderNotSet,
+                Properties.Resources.Error_FolderNotFound,
+                requireExistingBasePath: true);
+
             if (folder != null)
             {
                 OutputFolder = folder;
@@ -101,26 +106,7 @@ namespace PulseAPK.ViewModels
         [RelayCommand]
         private void OpenOutputFolder()
         {
-            if (string.IsNullOrWhiteSpace(OutputFolder))
-            {
-                MessageBox.Show(Properties.Resources.Error_OutputFolderNotSet, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
-                return;
-            }
-
-            if (!Directory.Exists(OutputFolder))
-            {
-                MessageBox.Show(string.Format(Properties.Resources.Error_FolderNotFound, OutputFolder), Properties.Resources.Error_OutputFolderNotSet, MessageBoxButton.OK, MessageBoxImage.Warning);
-                return;
-            }
-
-            try
-            {
-                Process.Start("explorer.exe", OutputFolder);
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(string.Format(Properties.Resources.Error_CouldNotOpenFolder, ex.Message), Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
-            }
+            Utils.BrowseUtils.TryOpenFolder(OutputFolder, Properties.Resources.Error_OutputFolderNotSet, Properties.Resources.Error_FolderNotFound);
         }
 
         [RelayCommand(CanExecute = nameof(CanRunDecompile))]


### PR DESCRIPTION
## Summary
- add a shared BrowseUtils helper to centralize folder selection and open-folder behavior
- update decompile and build browse commands to use the shared helper for consistent, validated paths

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a2f5e40c8322819261b59405d0a6)