### PR TITLE
Add message box utility helper

### DIFF
--- a/Utils/BrowseUtils.cs
+++ b/Utils/BrowseUtils.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Windows;
 
 namespace PulseAPK.Utils
 {
@@ -56,7 +55,7 @@ namespace PulseAPK.Utils
             }
             catch (Exception ex)
             {
-                MessageBox.Show(string.Format(Properties.Resources.Error_CouldNotOpenFolder, ex.Message), Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(string.Format(Properties.Resources.Error_CouldNotOpenFolder, ex.Message));
                 return false;
             }
         }
@@ -93,14 +92,14 @@ namespace PulseAPK.Utils
             {
                 if (!string.IsNullOrWhiteSpace(missingPathMessage))
                 {
-                    MessageBox.Show(missingPathMessage, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBoxUtils.ShowWarning(missingPathMessage);
                 }
                 return;
             }
 
             if (!string.IsNullOrWhiteSpace(folderNotFoundMessage))
             {
-                MessageBox.Show(string.Format(folderNotFoundMessage, path), Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBoxUtils.ShowWarning(string.Format(folderNotFoundMessage, path));
             }
         }
     }

--- a/Utils/MessageBoxUtils.cs
+++ b/Utils/MessageBoxUtils.cs
@@ -1,0 +1,32 @@
+using System.Windows;
+
+namespace PulseAPK.Utils
+{
+    public static class MessageBoxUtils
+    {
+        public static MessageBoxResult ShowInfo(string message, string? title = null)
+        {
+            return MessageBox.Show(message, title ?? Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        public static MessageBoxResult ShowWarning(string message, string? title = null)
+        {
+            return MessageBox.Show(message, title ?? Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
+        public static MessageBoxResult ShowError(string message, string? title = null)
+        {
+            return MessageBox.Show(message, title ?? Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        public static MessageBoxResult ShowQuestion(
+            string message,
+            string? title = null,
+            MessageBoxButton buttons = MessageBoxButton.YesNo,
+            MessageBoxImage icon = MessageBoxImage.Question,
+            MessageBoxResult defaultResult = MessageBoxResult.No)
+        {
+            return MessageBox.Show(message, title ?? Properties.Resources.AppTitle, buttons, icon, defaultResult);
+        }
+    }
+}

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Diagnostics;
 using PulseAPK.Services;
+using PulseAPK.Utils;
 
 namespace PulseAPK.ViewModels
 {
@@ -107,7 +108,7 @@ namespace PulseAPK.ViewModels
                 var (isValid, message) = Utils.FileSanitizer.ValidateProjectFolder(folder);
                 if (!isValid)
                 {
-                    MessageBox.Show(message, Properties.Resources.Warning_InvalidProjectFolder, MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBoxUtils.ShowWarning(message, Properties.Resources.Warning_InvalidProjectFolder);
                     return;
                 }
                 ProjectPath = folder;
@@ -137,20 +138,20 @@ namespace PulseAPK.ViewModels
         {
             if (string.IsNullOrWhiteSpace(ProjectPath))
             {
-                 MessageBox.Show(Properties.Resources.SelectProjectFolder, Properties.Resources.BuildHeader, MessageBoxButton.OK, MessageBoxImage.Warning);
+             MessageBoxUtils.ShowWarning(Properties.Resources.SelectProjectFolder, Properties.Resources.BuildHeader);
                  return;
             }
 
             var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
              if (string.IsNullOrWhiteSpace(apktoolPath) || !File.Exists(apktoolPath))
             {
-                MessageBox.Show(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
                 return;
             }
 
             if (File.Exists(OutputApkPath))
             {
-                 var result = MessageBox.Show($"The output file '{OutputApkPath}' already exists. Overwrite?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+                 var result = MessageBoxUtils.ShowQuestion($"The output file '{OutputApkPath}' already exists. Overwrite?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                  if (result != MessageBoxResult.Yes) return;
             }
 
@@ -164,18 +165,18 @@ namespace PulseAPK.ViewModels
                 if (exitCode == 0)
                 {
                     AppendLog(Properties.Resources.BuildSuccessful);
-                     MessageBox.Show(Properties.Resources.BuildSuccessful, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Information);
+                     MessageBoxUtils.ShowInfo(Properties.Resources.BuildSuccessful);
                 }
                 else
                 {
                      AppendLog($"{Properties.Resources.BuildFailed} (Exit Code: {exitCode})");
-                     MessageBox.Show(Properties.Resources.BuildFailed, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                     MessageBoxUtils.ShowError(Properties.Resources.BuildFailed);
                 }
             }
             catch (Exception ex)
             {
                 AppendLog($"{Properties.Resources.BuildFailed}: {ex.Message}");
-                MessageBox.Show(ex.Message, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(ex.Message);
             }
             finally
             {

--- a/ViewModels/DecompileViewModel.cs
+++ b/ViewModels/DecompileViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
 using System.Windows;
+using PulseAPK.Utils;
 
 namespace PulseAPK.ViewModels
 {
@@ -80,7 +81,7 @@ namespace PulseAPK.ViewModels
                 var (isValid, message) = Utils.FileSanitizer.ValidateApk(file);
                 if (!isValid)
                 {
-                    MessageBox.Show(message, "Invalid APK File", MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBoxUtils.ShowError(message, "Invalid APK File");
                     return;
                 }
                 ApkPath = file;
@@ -114,20 +115,20 @@ namespace PulseAPK.ViewModels
         {
             if (string.IsNullOrWhiteSpace(ApkPath))
             {
-                MessageBox.Show("Please select an APK file to decompile.", "Missing APK", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBoxUtils.ShowWarning("Please select an APK file to decompile.", "Missing APK");
                 return;
             }
 
             var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
             if (string.IsNullOrWhiteSpace(apktoolPath))
             {
-                MessageBox.Show(Properties.Resources.Error_MissingApktool, Properties.Resources.SettingsHeader, MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBoxUtils.ShowWarning(Properties.Resources.Error_MissingApktool, Properties.Resources.SettingsHeader);
                 return;
             }
 
             if (!File.Exists(apktoolPath))
             {
-                MessageBox.Show(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.Error_InvalidApkFile, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.Error_InvalidApkFile);
                 RunDecompileCommand.NotifyCanExecuteChanged();
                 return;
             }
@@ -142,7 +143,7 @@ namespace PulseAPK.ViewModels
 
             if (IsHighRiskOutputDirectory(normalizedOutputDir))
             {
-                MessageBox.Show($"The selected output folder '{normalizedOutputDir}' is unsafe. Choose a different location.", "Invalid output folder", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError($"The selected output folder '{normalizedOutputDir}' is unsafe. Choose a different location.", "Invalid output folder");
                 return;
             }
 
@@ -154,7 +155,7 @@ namespace PulseAPK.ViewModels
 
                 if (!isEmpty)
                 {
-                    var result = MessageBox.Show($"The output directory '{normalizedOutputDir}' already exists and is not empty. Overwrite its contents?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+                    var result = MessageBoxUtils.ShowQuestion($"The output directory '{normalizedOutputDir}' already exists and is not empty. Overwrite its contents?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
 
                     if (result != MessageBoxResult.Yes)
                     {
@@ -174,18 +175,18 @@ namespace PulseAPK.ViewModels
                 if (exitCode == 0)
                 {
                     AppendLog(Properties.Resources.DecompileSuccessful);
-                    MessageBox.Show(Properties.Resources.DecompileSuccessful, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBoxUtils.ShowInfo(Properties.Resources.DecompileSuccessful);
                 }
                 else
                 {
                     AppendLog($"{Properties.Resources.DecompileFailed} (Exit Code: {exitCode})");
-                    MessageBox.Show(Properties.Resources.DecompileFailed, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                    MessageBoxUtils.ShowError(Properties.Resources.DecompileFailed);
                 }
             }
             catch (Exception ex)
             {
                 AppendLog($"{Properties.Resources.DecompileFailed}: {ex.Message}");
-                MessageBox.Show(ex.Message, Properties.Resources.AppTitle, MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(ex.Message);
             }
             finally
             {

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using System;
 using System.IO;
 using System.Linq;
+using PulseAPK.Utils;
 
 namespace PulseAPK.ViewModels
 {
@@ -46,7 +47,7 @@ namespace PulseAPK.ViewModels
             var (isValid, message) = Utils.FileSanitizer.ValidateJar(file);
             if (!isValid)
             {
-                System.Windows.MessageBox.Show(message, Properties.Resources.Error_InvalidJarFile, System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
+                MessageBoxUtils.ShowError(message, Properties.Resources.Error_InvalidJarFile);
                 return;
             }
 

--- a/Views/BuildView.xaml.cs
+++ b/Views/BuildView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using PulseAPK.Utils;
 using PulseAPK.ViewModels;
 
 namespace PulseAPK.Views
@@ -42,12 +43,12 @@ namespace PulseAPK.Views
                         }
                         else
                         {
-                             MessageBox.Show(message, Properties.Resources.Warning_InvalidProjectFolder, MessageBoxButton.OK, MessageBoxImage.Warning);
+                             MessageBoxUtils.ShowWarning(message, Properties.Resources.Warning_InvalidProjectFolder);
                         }
                     }
                     else
                     {
-                        MessageBox.Show(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.BuildHeader, MessageBoxButton.OK, MessageBoxImage.Warning);
+                        MessageBoxUtils.ShowWarning(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.BuildHeader);
                     }
                 }
             }

--- a/Views/DecompileView.xaml.cs
+++ b/Views/DecompileView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using PulseAPK.Utils;
 
 namespace PulseAPK.Views
 {
@@ -31,7 +32,7 @@ namespace PulseAPK.Views
                 {
                     var file = files[0];
                     var (isValid, message) = Utils.FileSanitizer.ValidateApk(file);
-                    
+
                     if (isValid)
                     {
                         if (DataContext is ViewModels.DecompileViewModel vm)
@@ -41,7 +42,7 @@ namespace PulseAPK.Views
                     }
                     else
                     {
-                        MessageBox.Show(message, "Invalid APK File", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBoxUtils.ShowError(message, "Invalid APK File");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add MessageBoxUtils helper to centralize message dialog usage
- update view models and views to use the shared helper methods for errors, warnings, confirmations
- ensure folder browsing utilities reuse the centralized message box logic

## Testing
- dotnet test *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936aadfc1608322b14b05bb9682a044)