### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModels/AboutViewModel.cs
+++ b/ViewModels/AboutViewModel.cs
@@ -13,7 +13,7 @@ namespace PulseAPK.ViewModels
         
         private string getAppVersion() {
              var version = Assembly.GetExecutingAssembly().GetName().Version;
-             return string.Format(Properties.Resources.About_Version, version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "1.0.0");
+             return string.Format(Properties.Resources.About_Version, version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "1.0.1");
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- bump the project version metadata to 1.0.1
- update the About view model fallback version string to match the new release

## Testing
- `dotnet test` *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ca9b37108322ac0d189ff470975f)