### PR TITLE
Add signing toggle to Build APK view

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -473,7 +473,16 @@ namespace PulseAPK.Properties {
                 return ResourceManager.GetString("WaitingForCommand", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sign APK.
+        /// </summary>
+        public static string SignApk {
+            get {
+                return ResourceManager.GetString("SignApk", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use AAPT2.
         /// </summary>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -181,9 +181,12 @@
   <data name="BuildHeader" xml:space="preserve">
     <value>Build APK</value>
   </data>
-  <data name="SelectProjectFolder" xml:space="preserve">
+    <data name="SelectProjectFolder" xml:space="preserve">
     <value>Select Project Folder</value>
-  </data>
+    </data>
+    <data name="SignApk" xml:space="preserve">
+      <value>Sign APK</value>
+    </data>
     <data name="UseAapt2" xml:space="preserve">
       <value>Use AAPT2</value>
     </data>

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -31,6 +31,9 @@ namespace PulseAPK.ViewModels
         private bool _useAapt2;
 
         [ObservableProperty]
+        private bool _signApk = true;
+
+        [ObservableProperty]
         private string _consoleLog = Properties.Resources.WaitingForCommand;
 
         [ObservableProperty]
@@ -95,6 +98,7 @@ namespace PulseAPK.ViewModels
             RunBuildCommand.NotifyCanExecuteChanged();
         }
         partial void OnUseAapt2Changed(bool value) => UpdateCommandPreview();
+        partial void OnSignApkChanged(bool value) => UpdateCommandPreview();
 
         [RelayCommand]
         private void BrowseProject()
@@ -158,8 +162,8 @@ namespace PulseAPK.ViewModels
                  if (result != MessageBoxResult.Yes) return;
             }
 
-            var signedApkPath = GetSignedApkPath(OutputApkPath);
-            if (!string.IsNullOrWhiteSpace(signedApkPath) && File.Exists(signedApkPath))
+            var signedApkPath = SignApk ? GetSignedApkPath(OutputApkPath) : string.Empty;
+            if (SignApk && !string.IsNullOrWhiteSpace(signedApkPath) && File.Exists(signedApkPath))
             {
                 var result = MessageBoxUtils.ShowQuestion($"The signed output file '{signedApkPath}' already exists. Overwrite?", "Confirm overwrite", MessageBoxButton.YesNo, MessageBoxImage.Warning);
                 if (result != MessageBoxResult.Yes) return;
@@ -176,7 +180,7 @@ namespace PulseAPK.ViewModels
                 {
                     AppendLog(Properties.Resources.BuildSuccessful);
 
-                    if (!string.IsNullOrWhiteSpace(signedApkPath))
+                    if (SignApk && !string.IsNullOrWhiteSpace(signedApkPath))
                     {
                         await RunSigningAsync(OutputApkPath, signedApkPath);
                     }
@@ -372,6 +376,11 @@ namespace PulseAPK.ViewModels
 
         private string BuildSigningCommandPreview(string outputApk)
         {
+            if (!SignApk)
+            {
+                return string.Empty;
+            }
+
             var hasOutputPath = !string.IsNullOrWhiteSpace(outputApk) && outputApk != "<output apk>";
             var signedApk = GetSignedApkPath(OutputApkPath);
 

--- a/Views/BuildView.xaml
+++ b/Views/BuildView.xaml
@@ -57,6 +57,7 @@
 
             <StackPanel Grid.Column="0" Margin="0,0,40,0">
                 <CheckBox Content="{x:Static properties:Resources.UseAapt2}" IsChecked="{Binding UseAapt2}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
+                <CheckBox Content="{x:Static properties:Resources.SignApk}" IsChecked="{Binding SignApk}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">


### PR DESCRIPTION
## Summary
- add a checkbox in the Build APK view to control signing with ubersign
- add a Sign APK resource string and bind the checkbox to a new view model property
- gate signing logic and previews on the new SignApk flag

## Testing
- dotnet build *(fails: dotnet not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69390b99268c8322823b34a5cc8c6ae4)