### PR TITLE
Fix ubersign arguments for output directory

### DIFF
--- a/Services/UbersignRunner.cs
+++ b/Services/UbersignRunner.cs
@@ -38,7 +38,8 @@ namespace PulseAPK.Services
             outputDirectory ??= Directory.GetCurrentDirectory();
             Directory.CreateDirectory(outputDirectory);
 
-            var ubersignArguments = $"-a \"{inputApk}\" -o \"{outputDirectory}\" --allowResign --overwrite";
+            // When providing an output directory, ubersign does not allow the overwrite flag.
+            var ubersignArguments = $"-a \"{inputApk}\" -o \"{outputDirectory}\" --allowResign";
 
             var startInfo = isJar
                 ? new ProcessStartInfo


### PR DESCRIPTION
## Summary
- remove the conflicting overwrite flag when calling ubersign with an output directory

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939141120c883229e10c1638a8618d1)