### PR TITLE
Detect missing signed APK output from ubersign

### DIFF
--- a/Services/UbersignRunner.cs
+++ b/Services/UbersignRunner.cs
@@ -92,26 +92,11 @@ namespace PulseAPK.Services
                 return process.ExitCode;
             }
 
-            var inputFileName = Path.GetFileNameWithoutExtension(inputApk);
-            var expectedNames = new[]
-            {
-                $"{inputFileName}-aligned-signed.apk",
-                $"{inputFileName}-signed.apk"
-            };
-
-            var createdFile = expectedNames
-                .Select(name => Path.Combine(outputDirectory, name))
-                .FirstOrDefault(File.Exists);
-
-            if (createdFile == null)
-            {
-                createdFile = Directory.GetFiles(outputDirectory, "*.apk", SearchOption.TopDirectoryOnly)
-                    .OrderByDescending(File.GetLastWriteTimeUtc)
-                    .FirstOrDefault();
-            }
+            var createdFile = FindSignedApk(inputApk, outputDirectory);
 
             if (string.IsNullOrWhiteSpace(createdFile))
             {
+                OutputDataReceived?.Invoke("Signing completed but no signed APK was produced in the output directory.");
                 return 1;
             }
 
@@ -137,6 +122,20 @@ namespace PulseAPK.Services
 
             var windowsExecutable = Path.Combine(root, "ubersign.exe");
             return File.Exists(windowsExecutable) ? (windowsExecutable, false) : (jarPath, true);
+        }
+
+        private static string? FindSignedApk(string inputApk, string outputDirectory)
+        {
+            var inputFileName = Path.GetFileNameWithoutExtension(inputApk);
+            var expectedNames = new[]
+            {
+                $"{inputFileName}-aligned-signed.apk",
+                $"{inputFileName}-signed.apk"
+            };
+
+            return expectedNames
+                .Select(name => Path.Combine(outputDirectory, name))
+                .FirstOrDefault(File.Exists);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure signing only reports success when ubersign actually produces a signed APK
- surface a clear log message when no signed artifact is generated

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391536cae88322a7d20e4569c38e2e)