### PR TITLE
Handle alternate ubersign output names

### DIFF
--- a/Services/UbersignRunner.cs
+++ b/Services/UbersignRunner.cs
@@ -130,12 +130,29 @@ namespace PulseAPK.Services
             var expectedNames = new[]
             {
                 $"{inputFileName}-aligned-signed.apk",
-                $"{inputFileName}-signed.apk"
+                $"{inputFileName}-signed.apk",
+                $"{inputFileName}-aligned-debugSigned.apk",
+                $"{inputFileName}-debugSigned.apk"
             };
 
-            return expectedNames
+            var matchedFile = expectedNames
                 .Select(name => Path.Combine(outputDirectory, name))
                 .FirstOrDefault(File.Exists);
+
+            if (matchedFile is not null)
+            {
+                return matchedFile;
+            }
+
+            return Directory.EnumerateFiles(outputDirectory, "*.apk")
+                .Where(path =>
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(path);
+                    return fileName.StartsWith(inputFileName, StringComparison.OrdinalIgnoreCase)
+                           && fileName.Contains("signed", StringComparison.OrdinalIgnoreCase);
+                })
+                .OrderByDescending(File.GetLastWriteTimeUtc)
+                .FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
## Summary
- expand signed APK name detection to include debugSigned outputs from ubersign
- add a fallback search for files matching the input name that include "signed" when expected names are absent

## Testing
- dotnet test *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693916afd1b48322b844ea0f00825bd4)