### PR TITLE
Fix default ubersign path resolution

### DIFF
--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -7,7 +7,7 @@ namespace PulseAPK.Services
     public class AppSettings
     {
         public string ApktoolPath { get; set; } = "apktool.jar";
-        public string UbersignPath { get; set; } = "ubersign.jar";
+        public string UbersignPath { get; set; } = string.Empty;
     }
 
     public interface ISettingsService

--- a/Services/UbersignRunner.cs
+++ b/Services/UbersignRunner.cs
@@ -122,16 +122,23 @@ namespace PulseAPK.Services
 
         private (string Path, bool IsJar) GetUbersignPath()
         {
-            var configuredPath = _settingsService.Settings.UbersignPath?.Trim();
-            if (!string.IsNullOrWhiteSpace(configuredPath) && File.Exists(configuredPath))
-            {
-                var isJar = string.Equals(Path.GetExtension(configuredPath), ".jar", StringComparison.OrdinalIgnoreCase);
-                return (configuredPath, isJar);
-            }
-
             var root = string.IsNullOrWhiteSpace(AppDomain.CurrentDomain.BaseDirectory)
                 ? Directory.GetCurrentDirectory()
                 : AppDomain.CurrentDomain.BaseDirectory;
+
+            var configuredPath = _settingsService.Settings.UbersignPath?.Trim();
+            if (!string.IsNullOrWhiteSpace(configuredPath))
+            {
+                var resolvedPath = Path.IsPathRooted(configuredPath)
+                    ? configuredPath
+                    : Path.Combine(root, configuredPath);
+
+                if (File.Exists(resolvedPath))
+                {
+                    var isJar = string.Equals(Path.GetExtension(resolvedPath), ".jar", StringComparison.OrdinalIgnoreCase);
+                    return (resolvedPath, isJar);
+                }
+            }
 
             var jarPath = Path.Combine(root, "ubersign.jar");
             if (File.Exists(jarPath)) return (jarPath, true);

--- a/ViewModels/BuildViewModel.cs
+++ b/ViewModels/BuildViewModel.cs
@@ -389,15 +389,20 @@ namespace PulseAPK.ViewModels
 
             string signingCommand;
 
+            var appRoot = GetApplicationRootPath();
             var configuredUbersign = _settingsService.Settings.UbersignPath?.Trim().Trim('"');
             if (!string.IsNullOrWhiteSpace(configuredUbersign))
             {
-                var configuredExists = File.Exists(configuredUbersign);
-                var isJar = string.Equals(Path.GetExtension(configuredUbersign), ".jar", StringComparison.OrdinalIgnoreCase);
+                var resolvedUbersign = Path.IsPathRooted(configuredUbersign)
+                    ? configuredUbersign
+                    : Path.Combine(appRoot, configuredUbersign);
+
+                var configuredExists = File.Exists(resolvedUbersign);
+                var isJar = string.Equals(Path.GetExtension(resolvedUbersign), ".jar", StringComparison.OrdinalIgnoreCase);
 
                 signingCommand = isJar
-                    ? $"java -jar \"{configuredUbersign}\""
-                    : $"\"{configuredUbersign}\"";
+                    ? $"java -jar \"{resolvedUbersign}\""
+                    : $"\"{resolvedUbersign}\"";
 
                 if (!configuredExists)
                 {
@@ -406,8 +411,8 @@ namespace PulseAPK.ViewModels
             }
             else
             {
-                var ubersignJarPath = Path.Combine(GetApplicationRootPath(), "ubersign.jar");
-                var ubersignPath = Path.Combine(GetApplicationRootPath(), "ubersign");
+                var ubersignJarPath = Path.Combine(appRoot, "ubersign.jar");
+                var ubersignPath = Path.Combine(appRoot, "ubersign");
                 var windowsUbersign = $"{ubersignPath}.exe";
 
                 if (File.Exists(ubersignJarPath))


### PR DESCRIPTION
## Summary
- default ubersign path to empty so unspecified installs fall back to the app root
- resolve configured ubersign paths relative to the application root before running signing
- align signing preview to show the resolved ubersign location

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391ac9187c8322acfdfa8e2f43cac0)