### PR TITLE
Restrict Ubersigner browse to jar files

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -340,7 +340,7 @@ namespace PulseAPK.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Ubersign Files (*.jar;*.exe)|*.jar;*.exe|All Files (*.*)|*.*.
+        ///   Looks up a localized string similar to Ubersign Jar Files (*.jar)|*.jar.
         /// </summary>
         public static string FileFilter_Ubersign {
             get {

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -148,9 +148,9 @@
   <data name="FileFilter_Jar" xml:space="preserve">
     <value>Jar Files (*.jar)|*.jar</value>
   </data>
-  <data name="FileFilter_Ubersign" xml:space="preserve">
-    <value>Ubersign Files (*.jar;*.exe)|*.jar;*.exe|All Files (*.*)|*.*</value>
-  </data>
+    <data name="FileFilter_Ubersign" xml:space="preserve">
+        <value>Ubersign Jar Files (*.jar)|*.jar</value>
+    </data>
   <data name="SettingsHeader" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/Utils/FileSanitizer.cs
+++ b/Utils/FileSanitizer.cs
@@ -36,12 +36,7 @@ namespace PulseAPK.Utils
                 return ValidateJar(path);
             }
 
-            if (extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                return (true, string.Empty);
-            }
-
-            return (false, "File must be a .jar or .exe executable.");
+            return (false, "File must be a .jar file.");
         }
 
         public static (bool IsValid, string Message) ValidateProjectFolder(string path)


### PR DESCRIPTION
## Summary
- update Ubersigner file picker to only present JAR options
- tighten Ubersigner validation to require JAR files

## Testing
- dotnet test *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392b909874832298fd5fb5a3c7d697)