### PR TITLE
Use informational version for about dialog

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <Version>1.0.1</Version>
+    <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ViewModels/AboutViewModel.cs
+++ b/ViewModels/AboutViewModel.cs
@@ -11,9 +11,15 @@ namespace PulseAPK.ViewModels
         public string DeveloperName { get; } = "Dmitry Yarygin";
         public string Year { get; } = "2025";
         
-        private string getAppVersion() {
-             var version = Assembly.GetExecutingAssembly().GetName().Version;
-             return string.Format(Properties.Resources.About_Version, version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "1.0.1");
+        private string getAppVersion()
+        {
+            var informationalVersion = Assembly.GetExecutingAssembly()
+                                               .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                                               .InformationalVersion;
+
+            var version = string.IsNullOrWhiteSpace(informationalVersion) ? "1.0.1" : informationalVersion;
+
+            return string.Format(Properties.Resources.About_Version, version);
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- retrieve the informational version attribute for the About view version display
- fall back to a default version string when the attribute is missing
- emit the informational version attribute by aligning it with the project version

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939307c53208322b93edc47fa4052c1)