### PR TITLE
Load analyser rules from external config

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -36,4 +36,10 @@
     <Resource Include="Resources\CyberUnpack.png" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="apk_analysis_rules.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Services/AnalysisRules.cs
+++ b/Services/AnalysisRules.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace PulseAPK.Services
+{
+    public class AnalysisRuleSet
+    {
+        [JsonPropertyName("library_paths")]
+        public List<string> LibraryPaths { get; set; } = new();
+
+        [JsonPropertyName("rules")]
+        public List<AnalysisRule> Rules { get; set; } = new();
+    }
+
+    public class AnalysisRule
+    {
+        [JsonPropertyName("category")]
+        public string Category { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("regex_patterns")]
+        public List<string> RegexPatterns { get; set; } = new();
+    }
+
+    public static class AnalysisRulesLoader
+    {
+        private const string RulesFileName = "apk_analysis_rules.txt";
+
+        public static AnalysisRuleSet LoadRules()
+        {
+            var filePath = ResolveRulesFilePath();
+
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException($"Analysis rules file not found at '{filePath}'.");
+            }
+
+            try
+            {
+                var fileContents = File.ReadAllText(filePath);
+                var rules = JsonSerializer.Deserialize<AnalysisRuleSet>(fileContents, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                if (rules == null)
+                {
+                    throw new InvalidOperationException("Failed to parse analysis rules file.");
+                }
+
+                return rules;
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"Invalid analysis rules format: {ex.Message}", ex);
+            }
+        }
+
+        private static string ResolveRulesFilePath()
+        {
+            var baseDirectory = AppContext.BaseDirectory ?? Directory.GetCurrentDirectory();
+            var directPath = Path.Combine(baseDirectory, RulesFileName);
+
+            if (File.Exists(directPath))
+            {
+                return directPath;
+            }
+
+            // When running from the build output, walk up to the project root.
+            var projectRootPath = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", RulesFileName));
+            if (File.Exists(projectRootPath))
+            {
+                return projectRootPath;
+            }
+
+            return directPath;
+        }
+    }
+}

--- a/Services/SmaliAnalyserService.cs
+++ b/Services/SmaliAnalyserService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -9,6 +8,13 @@ namespace PulseAPK.Services
 {
     public class SmaliAnalyserService
     {
+        private readonly AnalysisRuleSet _ruleSet;
+
+        public SmaliAnalyserService()
+        {
+            _ruleSet = AnalysisRulesLoader.LoadRules();
+        }
+
         public async Task<AnalysisResult> AnalyseProjectAsync(string projectPath, Action<string> logCallback)
         {
             var result = new AnalysisResult();
@@ -41,12 +47,12 @@ namespace PulseAPK.Services
                     try
                     {
                         var lines = File.ReadAllLines(file);
-                        
+
                         // Run all detections on this file
                         AnalyzeFile(file, lines, result);
-                        
+
                         processedFiles++;
-                        
+
                         // Report progress periodically
                         if (processedFiles % reportInterval == 0 || processedFiles == totalFiles)
                         {
@@ -65,7 +71,7 @@ namespace PulseAPK.Services
 
         private void AnalyzeFile(string filePath, string[] lines, AnalysisResult result)
         {
-            // Skip library classes according to DETECTION_RULES.md
+            // Skip library classes according to the configured rules
             if (IsLibraryClass(filePath))
             {
                 return;
@@ -74,61 +80,36 @@ namespace PulseAPK.Services
             for (int i = 0; i < lines.Length; i++)
             {
                 var line = lines[i];
-                
-                // Check for root detection patterns
-                if (CheckPatterns(line, GetRootCheckPatterns()))
+
+                foreach (var rule in _ruleSet.Rules)
                 {
-                    result.RootChecks.Add(new Finding
+                    if (CheckPatterns(line, rule.RegexPatterns))
                     {
-                        FilePath = filePath,
-                        LineNumber = i + 1,
-                        Context = line.Trim()
-                    });
+                        AddFinding(result, rule.Category, filePath, i + 1, line.Trim());
+                    }
                 }
-                
-                // Check for emulator detection patterns
-                if (CheckPatterns(line, GetEmulatorCheckPatterns()))
-                {
-                    result.EmulatorChecks.Add(new Finding
-                    {
-                        FilePath = filePath,
-                        LineNumber = i + 1,
-                        Context = line.Trim()
-                    });
-                }
-                
-                // Check for hardcoded credentials patterns
-                if (CheckPatterns(line, GetCredentialPatterns()))
-                {
-                    result.HardcodedCredentials.Add(new Finding
-                    {
-                        FilePath = filePath,
-                        LineNumber = i + 1,
-                        Context = line.Trim()
-                    });
-                }
-                
-                // Check for SQL query patterns
-                if (CheckPatterns(line, GetSqlPatterns()))
-                {
-                    result.SqlQueries.Add(new Finding
-                    {
-                        FilePath = filePath,
-                        LineNumber = i + 1,
-                        Context = line.Trim()
-                    });
-                }
-                
-                // Check for HTTP/HTTPS URL patterns
-                if (CheckPatterns(line, GetHttpUrlPatterns()))
-                {
-                    result.HttpUrls.Add(new Finding
-                    {
-                        FilePath = filePath,
-                        LineNumber = i + 1,
-                        Context = line.Trim()
-                    });
-                }
+            }
+        }
+
+        private void AddFinding(AnalysisResult result, string category, string filePath, int lineNumber, string context)
+        {
+            switch (category.ToLowerInvariant())
+            {
+                case "root_check":
+                    result.RootChecks.Add(new Finding { FilePath = filePath, LineNumber = lineNumber, Context = context });
+                    break;
+                case "emulator_check":
+                    result.EmulatorChecks.Add(new Finding { FilePath = filePath, LineNumber = lineNumber, Context = context });
+                    break;
+                case "hardcoded_creds":
+                    result.HardcodedCredentials.Add(new Finding { FilePath = filePath, LineNumber = lineNumber, Context = context });
+                    break;
+                case "sql_query":
+                    result.SqlQueries.Add(new Finding { FilePath = filePath, LineNumber = lineNumber, Context = context });
+                    break;
+                case "http_url":
+                    result.HttpUrls.Add(new Finding { FilePath = filePath, LineNumber = lineNumber, Context = context });
+                    break;
             }
         }
 
@@ -136,25 +117,10 @@ namespace PulseAPK.Services
         {
             // Normalize path separators for comparison
             var normalizedPath = filePath.Replace("/", "\\").ToLowerInvariant();
-            
-            // Library path patterns to filter out
-            var libraryPatterns = new[]
-            {
-                "\\androidx\\",
-                "\\kotlin\\",
-                "\\kotlinx\\",
-                "\\com\\google\\",
-                "\\com\\squareup\\",
-                "\\okhttp3\\",
-                "\\okio\\",
-                "\\retrofit2\\",
-                "\\com\\android\\",
-                "\\android\\support\\"
-            };
 
-            foreach (var pattern in libraryPatterns)
+            foreach (var pattern in _ruleSet.LibraryPaths)
             {
-                if (normalizedPath.Contains(pattern))
+                if (normalizedPath.Contains(pattern.ToLowerInvariant()))
                 {
                     return true;
                 }
@@ -162,7 +128,7 @@ namespace PulseAPK.Services
             return false;
         }
 
-        private bool CheckPatterns(string line, string[] patterns)
+        private bool CheckPatterns(string line, IEnumerable<string> patterns)
         {
             foreach (var pattern in patterns)
             {
@@ -179,149 +145,6 @@ namespace PulseAPK.Services
                 }
             }
             return false;
-        }
-
-        private string[] GetRootCheckPatterns()
-        {
-            return new[]
-            {
-                // Runtime.exec() with su/magisk/busybox/superuser/xposed
-                @"Runtime.*exec.*[""'](su|magisk|busybox|superuser|xposed)[""']",
-                
-                // Root binary paths
-                @"const-string.*[""/]system/(xbin|bin)/(su|magisk|busybox)[""']",
-                @"const-string.*[""/]sbin/su[""']",
-                
-                // Known root management packages
-                @"const-string.*[""']com\.topjohnwu\.magisk",
-                @"const-string.*[""']eu\.chainfire\.supersu",
-                @"const-string.*[""']com\.noshufou\.android\.su",
-                @"const-string.*[""']com\.koushikdutta\.superuser",
-                @"const-string.*[""']de\.robv\.android\.xposed",
-                
-                // Root-specific file paths
-                @"const-string.*[""/]system/app/(Superuser|SuperSU|Magisk)",
-                @"const-string.*[""/]data/local/tmp[""']",
-                
-                // Build.TAGS with root/debug indicators (only with Build context)
-                @"Build.*TAGS.*test-keys",
-                @"Build.*TAGS.*dev-keys",
-                @"Build.*TAGS.*userdebug",
-                
-                // Root detection library names
-                @"RootBeer",
-                @"RootTools",
-                @"isDeviceRooted",
-                @"checkRootMethod"
-            };
-        }
-
-        private string[] GetEmulatorCheckPatterns()
-        {
-            return new[]
-            {
-                // System property checks for emulator
-                @"const-string.*[""']ro\.kernel\.qemu[""']",
-                @"const-string.*[""']ro\.hardware[""'].*goldfish",
-                @"const-string.*[""']ro\.product\.model[""'].*sdk",
-                @"const-string.*[""']ro\.product\.model[""'].*Emulator",
-                
-                // Clear emulator product names
-                @"const-string.*[""'](generic_x86|sdk_gphone|google_sdk|sdk.*x86)[""']",
-                
-                // Emulator software names
-                @"const-string.*[""'](Genymotion|BlueStacks|NoxPlayer|MEmu|LDPlayer)[""']",
-                
-                // Fake IMEI patterns used by emulators
-                @"const-string.*[""'](15555215554|15555215556|15555215558)[""']",
-                @"const-string.*[""']0000000000000000[""']",
-                
-                // Build fingerprint checks (only with Build context)
-                @"Build.*FINGERPRINT.*generic",
-                @"Build.*FINGERPRINT.*test-keys",
-                @"Build.*MODEL.*sdk",
-                @"Build.*MODEL.*Emulator",
-                
-                // Emulator detection methods
-                @"isEmulator",
-                @"checkEmulator",
-                @"detectEmulator"
-            };
-        }
-
-        private string[] GetCredentialPatterns()
-        {
-            return new[]
-            {
-                // Authorization headers (clear indicators)
-                @"const-string.*[""']Authorization:\s*(Bearer|Basic|Token)\s+[A-Za-z0-9\-_\.]+",
-                @"const-string.*[""'](Bearer|Basic)\s+[A-Za-z0-9\-_\.]{20,}[""']",
-                
-                // API keys (long alphanumeric strings labeled as key/token)
-                @"sput-object.*\.(api_?key|api_?token|auth_?token|access_?token)",
-                @"const-string.*[A-Za-z0-9]{32,}.*\.(api_?key|token|secret)",
-                
-                // Base64-like secrets (avoid short strings and UI labels)
-                @"const-string.*[""'][A-Za-z0-9+/]{40,}={0,2}[""']",
-                
-                // Long hex secrets (likely keys, not colors)
-                @"const-string.*[""'][0-9A-Fa-f]{40,}[""']",
-                
-                // Password/secret assignment (avoid InputType/AutofillHint)
-                @"\.field.*password.*Ljava/lang/String;.*[""'][^""']{6,}[""']",
-                @"\.field.*secret.*Ljava/lang/String;.*[""'][^""']{6,}[""']",
-                @"\.field.*api_?key.*Ljava/lang/String;.*[""'][^""']{10,}[""']",
-                
-                // Hardcoded basic auth credentials
-                @"const-string.*[""'][a-zA-Z0-9_]+:[a-zA-Z0-9_]{8,}@",
-                
-                // AWS/cloud provider keys
-                @"const-string.*[""'](AKIA|ASIA)[A-Z0-9]{16}[""']",
-                @"const-string.*[""']AIza[A-Za-z0-9\-_]{35}[""']"
-            };
-        }
-
-        private string[] GetSqlPatterns()
-        {
-            return new[]
-            {
-                // SQL keywords in string literals (check for actual SQL structure)
-                @"const-string.*[""']\s*SELECT\s+\*?\s+(FROM|[a-zA-Z_])",
-                @"const-string.*[""']\s*INSERT\s+INTO\s+",
-                @"const-string.*[""']\s*UPDATE\s+\w+\s+SET\s+",
-                @"const-string.*[""']\s*DELETE\s+FROM\s+",
-                @"const-string.*[""']\s*CREATE\s+TABLE\s+",
-                @"const-string.*[""']\s*DROP\s+TABLE\s+",
-                @"const-string.*[""']\s*ALTER\s+TABLE\s+",
-                
-                // SQL with WHERE clause (strong indicator)
-                @"const-string.*\s+WHERE\s+\w+\s*=",
-                
-                // SQLiteDatabase method calls (strong indicators)
-                @"invoke-virtual.*SQLiteDatabase;->execSQL\(Ljava/lang/String",
-                @"invoke-virtual.*SQLiteDatabase;->rawQuery\(Ljava/lang/String",
-                @"invoke-virtual.*SQLiteDatabase;->compileStatement\("
-            };
-        }
-
-        private string[] GetHttpUrlPatterns()
-        {
-            return new[]
-            {
-                // HTTP/HTTPS URLs in string literals
-                @"const-string.*[""']https?://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}[/\w\-\._~:/?#\[\]@!$&'()*+,;=]*[""']",
-                
-                // Interesting API endpoints
-                @"https?://[^""']+/(api|v1|v2|v3)/",
-                @"https?://[^""']+/(auth|login|signin|signup|register)/",
-                @"https?://[^""']+/(user|account|profile)/",
-                @"https?://[^""']+/(token|oauth|refresh)/",
-                @"https?://[^""']+/(payment|checkout|billing)/",
-                @"https?://[^""']+/(admin|dashboard)/",
-                
-                // Non-HTTPS URLs (potential security issue)
-                @"const-string.*[""']http://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}"
-            };
         }
     }
 

--- a/apk_analysis_rules.txt
+++ b/apk_analysis_rules.txt
@@ -1,0 +1,109 @@
+{
+  "library_paths": [
+    "\\androidx\\",
+    "\\kotlin\\",
+    "\\kotlinx\\",
+    "\\com\\google\\",
+    "\\com\\squareup\\",
+    "\\okhttp3\\",
+    "\\okio\\",
+    "\\retrofit2\\",
+    "\\com\\android\\",
+    "\\android\\support\\"
+  ],
+  "rules": [
+    {
+      "category": "root_check",
+      "description": "Runtime exec calls and common root binaries",
+      "regex_patterns": [
+        "Runtime.*exec.*[\\\"'](su|magisk|busybox|superuser|xposed)[\\\"']",
+        "const-string.*[\\\"/]system/(xbin|bin)/(su|magisk|busybox)[\\\"']",
+        "const-string.*[\\\"/]sbin/su[\\\"']",
+        "const-string.*[\\\"']com\\.topjohnwu\\.magisk",
+        "const-string.*[\\\"']eu\\.chainfire\\.supersu",
+        "const-string.*[\\\"']com\\.noshufou\\.android\\.su",
+        "const-string.*[\\\"']com\\.koushikdutta\\.superuser",
+        "const-string.*[\\\"']de\\.robv\\.android\\.xposed",
+        "const-string.*[\\\"/]system/app/(Superuser|SuperSU|Magisk)",
+        "const-string.*[\\\"/]data/local/tmp[\\\"']",
+        "Build.*TAGS.*test-keys",
+        "Build.*TAGS.*dev-keys",
+        "Build.*TAGS.*userdebug",
+        "RootBeer",
+        "RootTools",
+        "isDeviceRooted",
+        "checkRootMethod"
+      ]
+    },
+    {
+      "category": "emulator_check",
+      "description": "System property and Build checks for emulators",
+      "regex_patterns": [
+        "const-string.*[\\\"']ro\\.kernel\\.qemu[\\\"']",
+        "const-string.*[\\\"']ro\\.hardware[\\\"'].*goldfish",
+        "const-string.*[\\\"']ro\\.product\\.model[\\\"'].*sdk",
+        "const-string.*[\\\"']ro\\.product\\.model[\\\"'].*Emulator",
+        "const-string.*[\\\"'](generic_x86|sdk_gphone|google_sdk|sdk.*x86)[\\\"']",
+        "const-string.*[\\\"'](Genymotion|BlueStacks|NoxPlayer|MEmu|LDPlayer)[\\\"']",
+        "const-string.*[\\\"'](15555215554|15555215556|15555215558)[\\\"']",
+        "const-string.*[\\\"']0000000000000000[\\\"']",
+        "Build.*FINGERPRINT.*generic",
+        "Build.*FINGERPRINT.*test-keys",
+        "Build.*MODEL.*sdk",
+        "Build.*MODEL.*Emulator",
+        "isEmulator",
+        "checkEmulator",
+        "detectEmulator"
+      ]
+    },
+    {
+      "category": "hardcoded_creds",
+      "description": "Hardcoded secrets, tokens, and credentials",
+      "regex_patterns": [
+        "const-string.*[\\\"']Authorization:\\s*(Bearer|Basic|Token)\\s+[A-Za-z0-9\\\\-_\\.]+",
+        "const-string.*[\\\"'](Bearer|Basic)\\s+[A-Za-z0-9\\\\-_\\.]{20,}[\\\"']",
+        "sput-object.*\\.(api_?key|api_?token|auth_?token|access_?token)",
+        "const-string.*[A-Za-z0-9]{32,}.*\\.(api_?key|token|secret)",
+        "const-string.*[\\\"'][A-Za-z0-9+/]{40,}={0,2}[\\\"']",
+        "const-string.*[\\\"'][0-9A-Fa-f]{40,}[\\\"']",
+        "\\.field.*password.*Ljava/lang/String;.*[\\\"'][^\\\"']{6,}[\\\"']",
+        "\\.field.*secret.*Ljava/lang/String;.*[\\\"'][^\\\"']{6,}[\\\"']",
+        "\\.field.*api_?key.*Ljava/lang/String;.*[\\\"'][^\\\"']{10,}[\\\"']",
+        "const-string.*[\\\"'][a-zA-Z0-9_]+:[a-zA-Z0-9_]{8,}@",
+        "const-string.*[\\\"'](AKIA|ASIA)[A-Z0-9]{16}[\\\"']",
+        "const-string.*[\\\"']AIza[A-Za-z0-9\\\\-_]{35}[\\\"']"
+      ]
+    },
+    {
+      "category": "sql_query",
+      "description": "SQL statements and database calls",
+      "regex_patterns": [
+        "const-string.*[\\\"']\\s*SELECT\\s+\\*?\\s+(FROM|[a-zA-Z_])",
+        "const-string.*[\\\"']\\s*INSERT\\s+INTO\\s+",
+        "const-string.*[\\\"']\\s*UPDATE\\s+\\w+\\s+SET\\s+",
+        "const-string.*[\\\"']\\s*DELETE\\s+FROM\\s+",
+        "const-string.*[\\\"']\\s*CREATE\\s+TABLE\\s+",
+        "const-string.*[\\\"']\\s*DROP\\s+TABLE\\s+",
+        "const-string.*[\\\"']\\s*ALTER\\s+TABLE\\s+",
+        "const-string.*\\s+WHERE\\s+\\w+\\s*=",
+        "invoke-virtual.*SQLiteDatabase;->execSQL\\(Ljava/lang/String",
+        "invoke-virtual.*SQLiteDatabase;->rawQuery\\(Ljava/lang/String",
+        "invoke-virtual.*SQLiteDatabase;->compileStatement\\("
+      ]
+    },
+    {
+      "category": "http_url",
+      "description": "HTTP/HTTPS URLs and API endpoints",
+      "regex_patterns": [
+        "const-string.*[\\\"']https?://[a-zA-Z0-9\\\\-\\\\.]+\\.[a-zA-Z]{2,}[/\\\\w\\\\-\\\\._~:/?#\\\\[\\\\]@!$&'()*+,;=]*[\\\"']",
+        "https?://[^\\\"']+/(api|v1|v2|v3)/",
+        "https?://[^\\\"']+/(auth|login|signin|signup|register)/",
+        "https?://[^\\\"']+/(user|account|profile)/",
+        "https?://[^\\\"']+/(token|oauth|refresh)/",
+        "https?://[^\\\"']+/(payment|checkout|billing)/",
+        "https?://[^\\\"']+/(admin|dashboard)/",
+        "const-string.*[\\\"']http://[a-zA-Z0-9\\\\-\\\\.]+\\.[a-zA-Z]{2,}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `apk_analysis_rules.txt` to define library filters and regex-based analysis rules
- load analysis configuration at runtime for the Smali analyser instead of hardcoded patterns
- copy the rules file into the build output so it can be read by the application

## Testing
- dotnet build *(fails: command not found in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b312a25f88322989beffcdef2aecd)