### PR TITLE
Restore or generate smali_analysis_rules.json at runtime

### DIFF
--- a/Services/AnalysisRules.cs
+++ b/Services/AnalysisRules.cs
@@ -30,10 +30,161 @@ namespace PulseAPK.Services
     public static class AnalysisRulesLoader
     {
         private const string RulesFileName = "smali_analysis_rules.json";
+        private const string DefaultRulesJson = """
+            {
+              "library_paths": [
+                "\\androidx\\",
+                "\\kotlin\\",
+                "\\kotlinx\\",
+                "\\com\\google\\",
+                "\\com\\squareup\\",
+                "\\okhttp3\\",
+                "\\okio\\",
+                "\\retrofit2\\",
+                "\\com\\android\\",
+                "\\android\\support\\"
+              ],
+              "rules": [
+                {
+                  "category": "root_check",
+                  "description": "Runtime exec calls and common root binaries",
+                  "severity": "high",
+                  "regex_patterns": [
+                    "Runtime.*exec.*[\\\"'](su|magisk|busybox|superuser|xposed|zygisk)[\\\"']",
+                    "const-string.*[\\\"/]system/(xbin|bin)/(su|magisk|busybox|toybox)[\\\"']",
+                    "const-string.*[\\\"/]sbin/(su|magisk)[\\\"']",
+                    "const-string.*[\\\"']/(vendor|system/vendor)/bin/magisk[\\\"']",
+                    "const-string.*[\\\"'](com\\.topjohnwu\\.magisk|io\\.topjohnwu\\.magisk)",
+                    "const-string.*[\\\"']eu\\.chainfire\\.supersu",
+                    "const-string.*[\\\"']com\\.noshufou\\.android\\.su",
+                    "const-string.*[\\\"']com\\.koushikdutta\\.superuser",
+                    "const-string.*[\\\"'](de\\.robv\\.android\\.xposed|org\\.lsposed)",
+                    "const-string.*[\\\"'](com\\.thirdparty\\.superuser|com\\.kingoapp\\.root|com\\.kingroot\\.kinguser)",
+                    "const-string.*[\\\"/]system/app/(Superuser|SuperSU|Magisk)",
+                    "const-string.*[\\\"']/(data/local/tmp|/cache/magisk)[\\\"']",
+                    "const-string.*[\\\"']ro\\.build\\.tags[\\\"'].*(test-keys|dev-keys|userdebug)",
+                    "Build.*TAGS.*(test-keys|dev-keys|userdebug)",
+                    "const-string.*[\\\"']ro\\.debuggable[\\\"']",
+                    "const-string.*[\\\"']ro\\.debuggable[\\\"'].*=1",
+                    "const-string.*[\\\"']ro\\.secure[\\\"'].*=0",
+                    "const-string.*[\\\"']persist\\.sys\\.magisk[\\\"']",
+                    "const-string.*[\\\"']zygisk[\\\"']",
+                    "const-string.*[\\\"']/(vendor|system/vendor)/(x?bin|bin)/(su|magisk)[\\\"']",
+                    "const-string.*[\\\"']/(system/)?vendor/su[\\\"']",
+                    "const-string.*[\\\"']/(s?bin|vendor)/su[\\\"']",
+                    "const-string.*[\\\"']/system/(xbin|bin)/daemonsu[\\\"']",
+                    "const-string.*[\\\"']/(system|vendor|product)/etc/init/[^\\\"']*su\\.rc[\\\"']",
+                    "const-string.*[\\\"']mount[\\\"'].*(system|vendor).*(rw|remount)",
+                    "const-string.*(access|fopen|stat|lstat)\\(.*[\\\"']/system/(xbin|bin)/su[\\\"']",
+                    "const-string.*[\\\"']/system/xbin/su[\\\"'].*access",
+                    "RootBeer",
+                    "RootTools",
+                    "isDeviceRooted",
+                    "checkRootMethod",
+                    "findBinary",
+                    "canExecuteSu"
+                  ]
+                },
+                {
+                  "category": "emulator_check",
+                  "description": "System property and Build checks for emulators",
+                  "severity": "high",
+                  "regex_patterns": [
+                    "const-string.*[\\\"']ro\\.kernel\\.qemu[\\\"']",
+                    "const-string.*[\\\"']ro\\.hardware[\\\"'].*(goldfish|ranchu|qemu)",
+                    "const-string.*[\\\"']ro\\.product\\.model[\\\"'].*sdk",
+                    "const-string.*[\\\"']ro\\.product\\.model[\\\"'].*Emulator",
+                    "const-string.*[\\\"'](generic_x86|sdk_gphone|google_sdk|sdk.*x86|AOSP on IA Emulator)[\\\"']",
+                    "const-string.*[\\\"'](vbox86p|vbox86|twrp_emulator)[\\\"']",
+                    "const-string.*[\\\"'](Genymotion|BlueStacks|NoxPlayer|MEmu|LDPlayer|Memu|Andyroid|Droid4X)[\\\"']",
+                    "const-string.*[\\\"'](15555215554|15555215556|15555215558|15555215560)[\\\"']",
+                    "const-string.*[\\\"']0000000000000000[\\\"']",
+                    "const-string.*[\\\"'](qemu_prop|qemu\\.hw\\.mainkeys|init\\.rc_qemu|init\\.goldfish|qemud)[\\\"']",
+                    "const-string.*[\\\"']ro\\.product\\.(brand|device|name)[\\\"'].*(generic|emulator|vbox|sdk_gphone)",
+                    "const-string.*[\\\"']ro\\.hardware[\\\"'].*(vbox|ttvm)",
+                    "const-string.*[\\\"']gsm\\.operator\\.numeric[\\\"'].*(310260|000000)",
+                    "const-string.*[\\\"']gsm\\.operator\\.alpha[\\\"'].*(Android|Test)",
+                    "Build.*FINGERPRINT.*(generic|vbox|emulator|sdk|andy|tstvbox|x86)",
+                    "Build.*FINGERPRINT.*test-keys",
+                    "Build.*MODEL.*(sdk|Emulator|Android SDK built for|vbox86p)",
+                    "Build.*MANUFACTURER.*(unknown|Genymotion|Google|vbox|tstvbox)",
+                    "const-string.*[\\\"'](ranchu|goldfish|qemu)\\.pipe[\\\"']",
+                    "isEmulator",
+                    "checkEmulator",
+                    "detectEmulator",
+                    "const-string.*[\\\"']/dev/(qemu_pipe|ranchu_pipe|vboxguest|vport|qemu_trace|goldfish_pipe)[\\\"']",
+                    "const-string.*[\\\"']/proc/tty/drivers[\\\"']",
+                    "const-string.*[\\\"']/proc/cpuinfo[\\\"'].*(intel|amd).*hypervisor",
+                    "const-string.*[\\\"']hypervisor[\\\"'].*(Intel|AMD|VirtualBox|KVM)",
+                    "const-string.*[\\\"'](vbox|virtio|qemu|tcg)[\\\"'].*cpu"
+                  ]
+                },
+                {
+                  "category": "hardcoded_creds",
+                  "description": "Hardcoded secrets, tokens, and credentials",
+                  "severity": "medium",
+                  "regex_patterns": [
+                    "const-string.*[\\\"']Authorization:\\s*(Bearer|Basic|Token)\\s+[A-Za-z0-9\\-_\\.]+",
+                    "const-string.*[\\\"'](Bearer|Basic)\\s+[A-Za-z0-9\\-_\\.]{20,}[\\\"']",
+                    "sput-object.*\\.(api_?key|api_?token|auth_?token|access_?token)",
+                    "const-string.*(?i)(key|secret|token|password|passphrase).{0,8}[\\\"'][A-Za-z0-9+/]{32,}={0,2}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|password|passphrase).{0,8}[\\\"'][0-9A-Fa-f]{32,}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|password).{0,6}[\\\"'][^\\\"']{12,}[\\\"']",
+                    "\\.field.*(?i)(password|secret|api_?key|access_?token).*Ljava/lang/String;.*[\\\"'][^\\\"']{6,}[\\\"']",
+                    "const-string.*[\\\"'][a-zA-Z0-9_]+:[a-zA-Z0-9_]{8,}@",
+                    "const-string.*[\\\"'](AKIA|ASIA)[A-Z0-9]{16}[\\\"']",
+                    "const-string.*[\\\"']AIza[A-Za-z0-9\\-_]{35}[\\\"']",
+                    "const-string.*(?i)(client_?secret|app_?secret|db_?password).*[\\\"'][^\\\"']{8,}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|pass(word)?|client_?secret).{0,8}[\\\"']AAA[A-Za-z0-9_-]{8,}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|pass(word)?|client_?secret).{0,8}[\\\"'][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|pass(word)?|client_?secret).{0,8}[\\\"'][0-9]{8,10}:[A-Za-z0-9_-]{30,}[\\\"']",
+                    "const-string.*(?i)(key|secret|token|pass(word)?|client_?secret).{0,8}[\\\"']AAAAAI[a-zA-Z0-9_-]{8,}[\\\"']"
+                  ]
+                },
+                {
+                  "category": "sql_query",
+                  "description": "SQL statements and database calls",
+                  "severity": "medium",
+                  "regex_patterns": [
+                    "const-string.*[\\\"']\\s*SELECT\\s+\\*?\\s+(FROM|[a-zA-Z_])",
+                    "const-string.*SELECT[^\\\"']*[\\\"']\\s*\\+",
+                    "const-string.*[\\\"']\\s*INSERT\\s+INTO\\s+",
+                    "const-string.*[\\\"']\\s*UPDATE\\s+\\w+\\s+SET\\s+",
+                    "const-string.*[\\\"']\\s*DELETE\\s+FROM\\s+",
+                    "const-string.*[\\\"']\\s*CREATE\\s+TABLE\\s+",
+                    "const-string.*[\\\"']\\s*DROP\\s+TABLE\\s+",
+                    "const-string.*[\\\"']\\s*ALTER\\s+TABLE\\s+",
+                    "const-string.*\\s+WHERE\\s+\\w+\\s*=",
+                    "invoke-virtual.*SQLiteDatabase;->execSQL\\(Ljava/lang/String",
+                    "invoke-virtual.*SQLiteDatabase;->rawQuery\\(Ljava/lang/String",
+                    "invoke-virtual.*SQLiteDatabase;->compileStatement\\("
+                  ]
+                },
+                {
+                  "category": "http_url",
+                  "description": "HTTP/HTTPS URLs and API endpoints",
+                  "severity": "medium",
+                  "regex_patterns": [
+                    "const-string.*[\\\"']https?://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,}[/\\w\\-\\._~:/?#\\[\\]@!$&'()*+,;=]*[\\\"']",
+                    "const-string.*[\\\"']http://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,}",
+                    "https?://[^\\\"']+/(api|v1|v2|v3)/",
+                    "https?://[^\\\"']+/(auth|login|signin|signup|register)/",
+                    "https?://[^\\\"']+/(user|account|profile)/",
+                    "https?://[^\\\"']+/(token|oauth|refresh)/",
+                    "https?://[^\\\"']+/(payment|checkout|billing)/",
+                    "https?://[^\\\"']+/(admin|dashboard)/",
+                    "const-string.*[\\\"']https?://[^\\\"']+/graphql[\\\"']",
+                    "const-string.*(?i)(endpoint|callback|webhook|graphql)[^\\n]{0,20}https?://[^\\\"']+",
+                    "https?://[^\\\"']+/(rest|api/v[0-9]+|callback|webhook)/"
+                  ]
+                }
+              ]
+            }
+            """;
 
         public static AnalysisRuleSet LoadRules()
         {
-            var filePath = ResolveRulesFilePath();
+            var filePath = EnsureRulesFileExists();
 
             if (!File.Exists(filePath))
             {
@@ -61,7 +212,7 @@ namespace PulseAPK.Services
             }
         }
 
-        private static string ResolveRulesFilePath()
+        private static string EnsureRulesFileExists()
         {
             var baseDirectory = AppContext.BaseDirectory ?? Directory.GetCurrentDirectory();
             var directPath = Path.Combine(baseDirectory, RulesFileName);
@@ -75,9 +226,11 @@ namespace PulseAPK.Services
             var projectRootPath = Path.GetFullPath(Path.Combine(baseDirectory, "..", "..", "..", RulesFileName));
             if (File.Exists(projectRootPath))
             {
-                return projectRootPath;
+                File.Copy(projectRootPath, directPath);
+                return directPath;
             }
 
+            File.WriteAllText(directPath, DefaultRulesJson);
             return directPath;
         }
     }


### PR DESCRIPTION
### Motivation
- The app previously required `smali_analysis_rules.json` to exist and would fail with `FileNotFoundException` when it was missing.
- Provide self-healing behavior so the app can restore or generate the rules file at runtime instead of failing.
- Ensure existing runtime copies are never overwritten during restore.

### Description
- Added an embedded fallback JSON constant `DefaultRulesJson` containing the default rules.
- Replaced the old resolver with `EnsureRulesFileExists()` and updated `LoadRules()` to call it instead of `ResolveRulesFilePath()`.
- `EnsureRulesFileExists()` behavior:
  - If `RulesFileName` already exists in `AppContext.BaseDirectory`, return it (do not overwrite).
  - If a project-root copy exists, copy it into the app base directory and return the copied path.
  - If neither exists, write the embedded `DefaultRulesJson` to the app base directory and return that path.
- File changed: `Services/AnalysisRules.cs` (added `DefaultRulesJson`, added `EnsureRulesFileExists()`, updated `LoadRules()`).

### Testing
- No automated tests were executed for this change.
- Behavior to verify manually: when the runtime `smali_analysis_rules.json` is missing, the loader restores it from the project-root file if present; otherwise it creates a new file from the embedded default. Existing files are not overwritten.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944e935671c832286e58e3ae26429a5)