### PR TITLE
Add Ubersign requirement to README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,8 @@ Before running **PulseAPK**, ensure you have the following:
 
 1.  **Java Runtime Environment (JRE)**: `apktool` requires Java. Make sure `java` is added to your system `PATH`.
 2.  **Apktool**: Download the latest `apktool.jar` from [ibotpeaches.github.io](https://ibotpeaches.github.io/Apktool/).
-3.  **.NET 8.0 Runtime**: Required to run the application on Windows.
+3.  **Ubersign (Uber APK Signer)**: Required for signing rebuilt APKs. Download the latest `uber-apk-signer.jar` from the [GitHub releases](https://github.com/patrickfav/uber-apk-signer/releases).
+4.  **.NET 8.0 Runtime**: Required to run the application on Windows.
 
 ## Quick Start Guide
 


### PR DESCRIPTION
### Motivation
- Rebuilt APKs produced by the app need a signing tool, and this requirement was not documented in the README.
- Provide users with a clear, canonical place to obtain the signer to avoid confusion during the compile/rebuild workflow.
- Keep the prerequisites section complete and helpful for first-time setup.

### Description
- Updated `README.MD` to add a new prerequisite entry for `Ubersign (Uber APK Signer)` and included a download link to the project's GitHub releases page.
- Noted the specific artifact name `uber-apk-signer.jar` as the file to obtain.
- Adjusted the prerequisites ordering so `.NET 8.0 Runtime` follows the new entry.
- This change modifies only the `README.MD` documentation and does not change application code.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946cc825ef08322bc9607bc1fa1e1dd)