### PR TITLE
Bump project version to 1.1.2

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 

--- a/ViewModels/AboutViewModel.cs
+++ b/ViewModels/AboutViewModel.cs
@@ -33,7 +33,7 @@ namespace PulseAPK.ViewModels
             }
 
             var version = string.IsNullOrWhiteSpace(informationalVersion)
-                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.1"
+                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.2"
                 : informationalVersion;
 
             return string.Format(Properties.Resources.About_Version, version);


### PR DESCRIPTION
### Motivation

- Prepare a new release by updating the project's metadata and the UI fallback version to 1.1.2.

### Description

- Updated the `<Version>` element in `PulseAPK.csproj` from `1.1.1` to `1.1.2`.
- Updated the About view model fallback version in `ViewModels/AboutViewModel.cs` from `"1.1.1"` to `"1.1.2"` (used in `Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.2"`).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a18be2a908322b0a6db30276c91a2)