### PR TITLE
Show detection context in analyser log

### DIFF
--- a/ViewModels/AnalyserViewModel.cs
+++ b/ViewModels/AnalyserViewModel.cs
@@ -71,7 +71,7 @@ namespace PulseAPK.ViewModels
                         AppendLog(Properties.Resources.FoundIn);
                         foreach (var finding in result.RootChecks.Take(10))
                         {
-                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber})");
+                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
                         }
                         if (result.RootChecks.Count > 10)
                         {
@@ -98,7 +98,7 @@ namespace PulseAPK.ViewModels
                         AppendLog(Properties.Resources.FoundIn);
                         foreach (var finding in result.EmulatorChecks.Take(10))
                         {
-                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber})");
+                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
                         }
                         if (result.EmulatorChecks.Count > 10)
                         {
@@ -125,7 +125,7 @@ namespace PulseAPK.ViewModels
                         AppendLog(Properties.Resources.FoundIn);
                         foreach (var finding in result.HardcodedCredentials.Take(10))
                         {
-                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber})");
+                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
                         }
                         if (result.HardcodedCredentials.Count > 10)
                         {
@@ -152,7 +152,7 @@ namespace PulseAPK.ViewModels
                         AppendLog(Properties.Resources.FoundIn);
                         foreach (var finding in result.SqlQueries.Take(10))
                         {
-                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber})");
+                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
                         }
                         if (result.SqlQueries.Count > 10)
                         {
@@ -179,7 +179,7 @@ namespace PulseAPK.ViewModels
                         AppendLog(Properties.Resources.FoundIn);
                         foreach (var finding in result.HttpUrls.Take(10))
                         {
-                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber})");
+                            AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
                         }
                         if (result.HttpUrls.Count > 10)
                         {


### PR DESCRIPTION
## Summary
- include the detected smali line contents alongside file and line entries in analyser console output

## Testing
- dotnet build PulseAPK.sln *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69552fa26ea88322b6ce35bc9d33c142)