### PR TITLE
Bump version to 1.1.4 and update About year to 2026

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 

--- a/ViewModels/AboutViewModel.cs
+++ b/ViewModels/AboutViewModel.cs
@@ -9,7 +9,7 @@ namespace PulseAPK.ViewModels
     {
         public string AppVersion => getAppVersion();
         public string DeveloperName { get; } = "Dmitry Yarygin";
-        public string Year { get; } = "2025";
+        public string Year { get; } = "2026";
 
         private string getAppVersion()
         {
@@ -33,7 +33,7 @@ namespace PulseAPK.ViewModels
             }
 
             var version = string.IsNullOrWhiteSpace(informationalVersion)
-                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.3"
+                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.4"
                 : informationalVersion;
 
             return string.Format(Properties.Resources.About_Version, version);


### PR DESCRIPTION
### Motivation
- Keep the app metadata current by updating the About window year and bumping the application version to `1.1.4` for build and display consistency.

### Description
- Set the `Year` property in `ViewModels/AboutViewModel.cs` to `"2026"` so the About window shows the correct year.
- Update the fallback version string in `AboutViewModel.getAppVersion()` from `"1.1.3"` to `"1.1.4"` so the displayed version matches the project version when no informational version is present.
- Bump `<Version>` in `PulseAPK.csproj` to `1.1.4` so build metadata and `InformationalVersion` reflect the new release.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a189713cc83228aff7694bb83e58f)