### PR TITLE
Show full APK analysis findings list

### DIFF
--- a/ViewModels/AnalyserViewModel.cs
+++ b/ViewModels/AnalyserViewModel.cs
@@ -69,13 +69,9 @@ namespace PulseAPK.ViewModels
                     {
                         AppendLog(Properties.Resources.RootCheckFound);
                         AppendLog(Properties.Resources.FoundIn);
-                        foreach (var finding in result.RootChecks.Take(10))
+                        foreach (var finding in result.RootChecks)
                         {
                             AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
-                        }
-                        if (result.RootChecks.Count > 10)
-                        {
-                            AppendLog($"  ... and {result.RootChecks.Count - 10} more");
                         }
                     }
                     else
@@ -96,13 +92,9 @@ namespace PulseAPK.ViewModels
                     {
                         AppendLog(Properties.Resources.EmulatorCheckFound);
                         AppendLog(Properties.Resources.FoundIn);
-                        foreach (var finding in result.EmulatorChecks.Take(10))
+                        foreach (var finding in result.EmulatorChecks)
                         {
                             AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
-                        }
-                        if (result.EmulatorChecks.Count > 10)
-                        {
-                            AppendLog($"  ... and {result.EmulatorChecks.Count - 10} more");
                         }
                     }
                     else
@@ -123,13 +115,9 @@ namespace PulseAPK.ViewModels
                     {
                         AppendLog(Properties.Resources.CredentialsFound);
                         AppendLog(Properties.Resources.FoundIn);
-                        foreach (var finding in result.HardcodedCredentials.Take(10))
+                        foreach (var finding in result.HardcodedCredentials)
                         {
                             AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
-                        }
-                        if (result.HardcodedCredentials.Count > 10)
-                        {
-                            AppendLog($"  ... and {result.HardcodedCredentials.Count - 10} more");
                         }
                     }
                     else
@@ -150,13 +138,9 @@ namespace PulseAPK.ViewModels
                     {
                         AppendLog(Properties.Resources.SqlQueriesFound);
                         AppendLog(Properties.Resources.FoundIn);
-                        foreach (var finding in result.SqlQueries.Take(10))
+                        foreach (var finding in result.SqlQueries)
                         {
                             AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
-                        }
-                        if (result.SqlQueries.Count > 10)
-                        {
-                            AppendLog($"  ... and {result.SqlQueries.Count - 10} more");
                         }
                     }
                     else
@@ -177,13 +161,9 @@ namespace PulseAPK.ViewModels
                     {
                         AppendLog(Properties.Resources.HttpUrlsFound);
                         AppendLog(Properties.Resources.FoundIn);
-                        foreach (var finding in result.HttpUrls.Take(10))
+                        foreach (var finding in result.HttpUrls)
                         {
                             AppendLog($"  - {GetRelativePath(finding.FilePath, ProjectPath)} (Line {finding.LineNumber}): {finding.Context}");
-                        }
-                        if (result.HttpUrls.Count > 10)
-                        {
-                            AppendLog($"  ... and {result.HttpUrls.Count - 10} more");
                         }
                     }
                     else


### PR DESCRIPTION
### Motivation
- The analysis output previously limited each category to the first 10 findings and appended a "... and N more" message, which hides full context strings during APK analysis.
- The change ensures the tool surfaces every matching string so users can see complete findings without truncation.

### Description
- Removed the `.Take(10)` caps so each category iterates over the entire results collection for `root_check`, `emulator_check`, `hardcoded_creds`, `sql_query`, and `http_url`.
- Removed the truncation messages that printed `"... and N more"` for those categories.
- Changes are contained in `ViewModels/AnalyserViewModel.cs` where the analysis results are appended to the console log.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a19c723248322a65ce92f88c8ee05)