### PR TITLE
Preserve full console logs and prevent UI freezes with buffered, virtualized console output

### DIFF
--- a/Views/AnalyserView.xaml
+++ b/Views/AnalyserView.xaml
@@ -65,9 +65,21 @@
                     <TextBlock Text="Console log" Foreground="{StaticResource Brush.TextPrimary}" VerticalAlignment="Center"/>
                 </Grid>
 
-                <ScrollViewer Grid.Row="1">
-                    <TextBox Text="{Binding ConsoleLog}" Foreground="{StaticResource Brush.TextSecondary}" FontFamily="Consolas" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Background="Transparent" BorderThickness="0"/>
-                </ScrollViewer>
+                <ListBox Grid.Row="1"
+                         ItemsSource="{Binding ConsoleLines}"
+                         Foreground="{StaticResource Brush.TextSecondary}"
+                         FontFamily="Consolas"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" TextWrapping="Wrap" Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
             </Grid>
         </Border>
 

--- a/Views/BuildView.xaml
+++ b/Views/BuildView.xaml
@@ -93,9 +93,21 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <TextBlock Text="Console log" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,0,0,10"/>
-                <ScrollViewer Grid.Row="1">
-                    <TextBox Text="{Binding ConsoleLog}" Foreground="{StaticResource Brush.TextSecondary}" FontFamily="Consolas" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Background="Transparent" BorderThickness="0"/>
-                </ScrollViewer>
+                <ListBox Grid.Row="1"
+                         ItemsSource="{Binding ConsoleLines}"
+                         Foreground="{StaticResource Brush.TextSecondary}"
+                         FontFamily="Consolas"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" TextWrapping="Wrap" Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
             </Grid>
         </Border>
     </Grid>

--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -84,9 +84,21 @@
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <TextBlock Text="Console log" Foreground="{StaticResource Brush.TextPrimary}" Margin="0,0,0,10"/>
-                <ScrollViewer Grid.Row="1">
-                    <TextBox Text="{Binding ConsoleLog}" Foreground="{StaticResource Brush.TextSecondary}" FontFamily="Consolas" IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" Background="Transparent" BorderThickness="0"/>
-                </ScrollViewer>
+                <ListBox Grid.Row="1"
+                         ItemsSource="{Binding ConsoleLines}"
+                         Foreground="{StaticResource Brush.TextSecondary}"
+                         FontFamily="Consolas"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" TextWrapping="Wrap" Foreground="{StaticResource Brush.TextSecondary}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
             </Grid>
         </Border>
     </Grid>


### PR DESCRIPTION
### Motivation
- Console output was stored as a single large `string` and frequently updated the UI, causing truncation and UI freezes when logs grew large. 
- The change aims to preserve the complete log text for reporting while keeping the UI responsive for very large outputs. 

### Description
- Reworked console handling to use a line-based `ObservableCollection<string>` (`ConsoleLines`) with a buffered `List<string>` (`_pendingLogLines`) and batched UI flushes (`ScheduleLogFlush`/`FlushLog`) in `ViewModels/AnalyserViewModel.cs`, `ViewModels/BuildViewModel.cs`, and `ViewModels/DecompileViewModel.cs`. 
- Retained a full-text `StringBuilder` (`_fullLogBuilder`) so the entire log is preserved and `SaveReport` now writes `_fullLogBuilder.ToString()` to reports. 
- Replaced `TextBox`-bound console views with virtualized `ListBox` item sources in `Views/AnalyserView.xaml`, `Views/BuildView.xaml`, and `Views/DecompileView.xaml` and enabled `VirtualizingStackPanel` recycling to keep scrolling and rendering responsive. 
- Added helpers to split incoming messages into lines (`SplitLines`), append to the full log (`AppendToFullLog`), and handle placeholder/preview states so command previews and initial messages remain functional. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3363e950832297590a5b6ba56885)