### PR TITLE
Bump analyzer console log limit to 900,000

### DIFF
--- a/ViewModels/AnalyserViewModel.cs
+++ b/ViewModels/AnalyserViewModel.cs
@@ -14,8 +14,8 @@ namespace PulseAPK.ViewModels
 {
     public partial class AnalyserViewModel : ObservableObject
     {
-        private const int MaxLogCharacters = 500_000;
-        private const int LogTrimTargetCharacters = 450_000;
+        private const int MaxLogCharacters = 900_000;
+        private const int LogTrimTargetCharacters = 850_000;
         private static readonly TimeSpan LogFlushInterval = TimeSpan.FromMilliseconds(150);
         private readonly Queue<string> _logLines = new Queue<string>();
         private readonly object _logLock = new object();


### PR DESCRIPTION
### Motivation
- Increase the analyzer console log capacity to accommodate larger analysis outputs by raising the max character allowance and adjusting the trim threshold.

### Description
- Update constants in `ViewModels/AnalyserViewModel.cs`: set `MaxLogCharacters` to `900_000` and `LogTrimTargetCharacters` to `850_000`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3d731e9c8322a066e1e079fc4d56)