### PR TITLE
Add 'Extract to APK folder' option in Decompile view

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -374,6 +374,15 @@ namespace PulseAPK.Properties {
                 return ResourceManager.GetString("KeepOriginalManifest", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Extract to a folder where APK is located.
+        /// </summary>
+        public static string ExtractToApkFolder {
+            get {
+                return ResourceManager.GetString("ExtractToApkFolder", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to About.

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -97,6 +97,9 @@
   <data name="KeepOriginalManifest" xml:space="preserve">
     <value>Keep Original Manifest</value>
   </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Extract to a folder where APK is located</value>
+  </data>
   <data name="DecodeSources" xml:space="preserve">
     <value>Decode Sources</value>
   </data>

--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -58,7 +58,8 @@
             <StackPanel Grid.Column="0" Margin="0,0,40,0">
                 <CheckBox Content="{x:Static properties:Resources.DecodeResources}" IsChecked="{Binding DecodeResources}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
                 <CheckBox Content="{x:Static properties:Resources.DecodeSources}" IsChecked="{Binding DecodeSources}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
-                <CheckBox Content="{x:Static properties:Resources.KeepOriginalManifest}" IsChecked="{Binding KeepOriginalManifest}" Style="{StaticResource CyberCheckBoxStyle}"/>
+                <CheckBox Content="{x:Static properties:Resources.KeepOriginalManifest}" IsChecked="{Binding KeepOriginalManifest}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
+                <CheckBox Content="{x:Static properties:Resources.ExtractToApkFolder}" IsChecked="{Binding ExtractToApkFolder}" Style="{StaticResource CyberCheckBoxStyle}"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1">
@@ -67,8 +68,27 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Static properties:Resources.OutputFolder}}" Style="{StaticResource CyberTextBoxStyle}" Tag="{x:Static properties:Resources.OutputFolder}" Height="30" VerticalContentAlignment="Center" Background="{StaticResource Brush.Panel}" Foreground="{StaticResource Brush.TextPrimary}" BorderBrush="{StaticResource Brush.BorderGlow}"/>
+                    <TextBox Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, TargetNullValue={x:Static properties:Resources.OutputFolder}}" Tag="{x:Static properties:Resources.OutputFolder}" Height="30" VerticalContentAlignment="Center" Background="{StaticResource Brush.Panel}" Foreground="{StaticResource Brush.TextPrimary}" BorderBrush="{StaticResource Brush.BorderGlow}">
+                        <TextBox.Style>
+                            <Style TargetType="TextBox" BasedOn="{StaticResource CyberTextBoxStyle}">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ExtractToApkFolder}" Value="True">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBox.Style>
+                    </TextBox>
                     <StackPanel Grid.Column="1" Orientation="Vertical" Margin="10,0,0,0">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding ExtractToApkFolder}" Value="True">
+                                        <Setter Property="IsEnabled" Value="False"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
                         <Button Content="{x:Static properties:Resources.Browse}" Style="{StaticResource CyberButtonStyle}" Height="30" Padding="16,0" MinWidth="90" Command="{Binding BrowseOutputFolderCommand}" Margin="0,0,0,4"/>
                         <Button Content="{x:Static properties:Resources.Open}" Style="{StaticResource CyberButtonStyle}" Height="30" Padding="16,0" MinWidth="90" Command="{Binding OpenOutputFolderCommand}" Margin="0,4,0,0"/>
                     </StackPanel>


### PR DESCRIPTION
### Motivation
- Provide an option to extract decompiled Smali/resources directly into the same folder as the selected APK and simplify the UI when that mode is selected.

### Description
- Add new resource string `ExtractToApkFolder` and corresponding designer property for the new checkbox label (`Properties/Resources.resx` and `Properties/Resources.Designer.cs`).
- Add a new observable property `ExtractToApkFolder` with change notification in `DecompileViewModel` and update the command preview when it changes.
- Implement `ResolveOutputDirectory`, `ResolveOutputDirectoryPreview`, and `GetApkDerivedOutputFolder` in `DecompileViewModel` and use `ResolveOutputDirectory()` for the actual decompile output path so the APK-folder option is respected during run.
- Update the UI in `Views/DecompileView.xaml` to add the new checkbox bound to `ExtractToApkFolder` and disable the output `TextBox` and the browse/open buttons when the option is selected.

### Testing
- No automated tests were run on the modified code (no CI/tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b50c92cb08322a1bb33acdda52ca2)