### PR TITLE
Bump version to 1.1.5 and add 1.1.x patch bump scripts

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.1.4</Version>
+    <Version>1.1.5</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 

--- a/ViewModels/AboutViewModel.cs
+++ b/ViewModels/AboutViewModel.cs
@@ -33,7 +33,7 @@ namespace PulseAPK.ViewModels
             }
 
             var version = string.IsNullOrWhiteSpace(informationalVersion)
-                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.4"
+                ? Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "1.1.5"
                 : informationalVersion;
 
             return string.Format(Properties.Resources.About_Version, version);

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -1,0 +1,30 @@
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$csprojPath = Join-Path $repoRoot "PulseAPK.csproj"
+$aboutPath = Join-Path $repoRoot "ViewModels/AboutViewModel.cs"
+
+$csprojContent = Get-Content -Raw -Path $csprojPath
+$versionMatch = [regex]::Match($csprojContent, "<Version>([^<]+)</Version>")
+
+if (-not $versionMatch.Success) {
+    Write-Error "Unable to determine current version from $csprojPath."
+    exit 1
+}
+
+$currentVersion = $versionMatch.Groups[1].Value
+
+if ($currentVersion -notmatch "^1\.1\.(\d+)$") {
+    Write-Error "Version '$currentVersion' is not in the expected 1.1.x format."
+    exit 1
+}
+
+$patch = [int]$Matches[1] + 1
+$nextVersion = "1.1.$patch"
+
+$csprojContent = $csprojContent -replace "<Version>[^<]+</Version>", "<Version>$nextVersion</Version>"
+Set-Content -Path $csprojPath -Value $csprojContent
+
+$aboutContent = Get-Content -Raw -Path $aboutPath
+$aboutContent = $aboutContent -replace "\?\? ""1\.1\.\d+""", "?? ""$nextVersion"""
+Set-Content -Path $aboutPath -Value $aboutContent
+
+Write-Host "Bumped version to $nextVersion."

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+csproj_path="${repo_root}/PulseAPK.csproj"
+about_path="${repo_root}/ViewModels/AboutViewModel.cs"
+
+current_version="$(sed -n 's/.*<Version>\(.*\)<\/Version>.*/\1/p' "${csproj_path}")"
+
+if [[ -z "${current_version}" ]]; then
+  echo "Unable to determine current version from ${csproj_path}." >&2
+  exit 1
+fi
+
+if [[ ! "${current_version}" =~ ^1\.1\.([0-9]+)$ ]]; then
+  echo "Version '${current_version}' is not in the expected 1.1.x format." >&2
+  exit 1
+fi
+
+patch="${BASH_REMATCH[1]}"
+next_patch=$((patch + 1))
+next_version="1.1.${next_patch}"
+
+perl -0pi -e "s/<Version>[^<]+<\\/Version>/<Version>${next_version}<\\/Version>/" "${csproj_path}"
+perl -0pi -e "s/\\?\\? \"1\\.1\\.\\d+\"/?? \"${next_version}\"/" "${about_path}"
+
+echo "Bumped version to ${next_version}."


### PR DESCRIPTION
### Motivation
- Update the project and About dialog fallback to the new release version 1.1.5.
- Provide simple, repeatable tools to increment the patch portion of versions in the 1.1.x line.

### Description
- Updated `<Version>` in `PulseAPK.csproj` from `1.1.4` to `1.1.5`.
- Updated the fallback version string in `ViewModels/AboutViewModel.cs` from `"1.1.4"` to `"1.1.5"`.
- Added `scripts/bump-version.sh`, a POSIX shell script that validates a `1.1.x` version, computes the next patch, and updates `PulseAPK.csproj` and the `AboutViewModel` fallback.
- Added `scripts/bump-version.ps1`, a PowerShell equivalent that performs the same validation and in-place updates for Windows environments.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c3c00a2208322b9ea0318a540af1d)