### PR TITLE
Add timestamped folder option for APK decompile output

### DIFF
--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -383,6 +383,15 @@ namespace PulseAPK.Properties {
                 return ResourceManager.GetString("ExtractToApkFolder", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Create an extracted folder with timestamp.
+        /// </summary>
+        public static string CreateTimestampedFolder {
+            get {
+                return ResourceManager.GetString("CreateTimestampedFolder", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to About.

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -100,6 +100,9 @@
   <data name="ExtractToApkFolder" xml:space="preserve">
     <value>Extract to a folder where APK is located</value>
   </data>
+  <data name="CreateTimestampedFolder" xml:space="preserve">
+    <value>Create an extracted folder with timestamp</value>
+  </data>
   <data name="DecodeSources" xml:space="preserve">
     <value>Decode Sources</value>
   </data>

--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -59,7 +59,18 @@
                 <CheckBox Content="{x:Static properties:Resources.DecodeResources}" IsChecked="{Binding DecodeResources}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
                 <CheckBox Content="{x:Static properties:Resources.DecodeSources}" IsChecked="{Binding DecodeSources}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
                 <CheckBox Content="{x:Static properties:Resources.KeepOriginalManifest}" IsChecked="{Binding KeepOriginalManifest}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,10"/>
-                <CheckBox Content="{x:Static properties:Resources.ExtractToApkFolder}" IsChecked="{Binding ExtractToApkFolder}" Style="{StaticResource CyberCheckBoxStyle}"/>
+                <CheckBox Content="{x:Static properties:Resources.ExtractToApkFolder}" IsChecked="{Binding ExtractToApkFolder}" Style="{StaticResource CyberCheckBoxStyle}" Margin="0,0,20,6"/>
+                <CheckBox Content="{x:Static properties:Resources.CreateTimestampedFolder}" IsChecked="{Binding CreateTimestampedFolder}" Margin="20,0,20,10">
+                    <CheckBox.Style>
+                        <Style TargetType="CheckBox" BasedOn="{StaticResource CyberCheckBoxStyle}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding ExtractToApkFolder}" Value="False">
+                                    <Setter Property="IsEnabled" Value="False"/>
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </CheckBox.Style>
+                </CheckBox>
             </StackPanel>
 
             <StackPanel Grid.Column="1">


### PR DESCRIPTION
### Motivation
- Provide an option in the Decompile view to create a timestamped extracted folder next to the APK so each decompile run can produce a unique output folder. 
- Keep the new option tied to the existing "extract to APK folder" behavior and automatically revert it when extracting to APK folder is disabled. 
- Update command preview and output resolution so the preview and runtime behavior reflect the timestamped folder when selected.

### Description
- Added a new observable property `CreateTimestampedFolder` and reset it when `ExtractToApkFolder` is turned off in `ViewModels/DecompileViewModel.cs`, and wired it into command preview via `UpdateCommandPreview`. 
- Implemented `GetTimestampedApkOutputFolder` and `GetTimestampedApkOutputFolderPreview` and updated `ResolveOutputDirectory` / `ResolveOutputDirectoryPreview` to return timestamped names when appropriate. 
- Added a new localized string `CreateTimestampedFolder` to `Properties/Resources.resx` and its accessor in `Properties/Resources.Designer.cs`. 
- Added a new checkbox to the UI in `Views/DecompileView.xaml` for `CreateTimestampedFolder`, which is enabled only when `ExtractToApkFolder` is checked.

### Testing
- No automated tests were executed for this change. 
- The change was committed locally (`git commit` completed) and the modified files are `Views/DecompileView.xaml`, `ViewModels/DecompileViewModel.cs`, `Properties/Resources.resx`, and `Properties/Resources.Designer.cs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c42d04468832292c784db64a311d7)